### PR TITLE
Adapted to operator-rs build_resource_name and create_config_map.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "stackable-zookeeper-crd"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=adapt_to_operator_pod_name_and_create_config_map#a099695d66b159c68b08b44139164a57de2eda3d"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#ecd6b8f3a9565a9f2c0d1191e0ae220b0be921fa"
 dependencies = [
  "k8s-openapi",
  "kube",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "async-trait"
@@ -82,9 +82,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
@@ -105,9 +105,9 @@ checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cd0be51cd9ea39adba1f11b1a82d0fb41674c800540e2817d510da21bf9508"
+checksum = "59c7d3aa11be45d56befebb10f4a8785fcb62aabddf5f33638efef922e505ec9"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
  "bytes",
  "fnv",
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
  "http",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -584,9 +584,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -692,9 +692,9 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "java-properties"
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8152fba26129a09bf30179092753b399760a305a218b8bc558f9a2087b5c1d70"
+checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
 dependencies = [
  "base64",
  "bytes",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b767df01404bb99fb75ac2ceded28ce34c30fdcffbb4346e2c44d30756bfba"
+checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
 dependencies = [
  "form_urlencoded",
  "http",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d0e5489859d9430689f64e69cacc9bf8cb68556f436c73a6a308d4e256b7a0"
+checksum = "95a28be5ca4f233b5dd872f426fdc75d6765c34576b590c44564982c05fdb400"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -822,21 +822,24 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8358421de932e06d0521700fc8ecfc7058c95509e0770d2da88be78cd737c07"
+checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
 dependencies = [
  "dashmap",
  "derivative",
  "futures",
+ "json-patch",
  "k8s-openapi",
  "kube",
  "pin-project 1.0.8",
  "serde",
+ "serde_json",
  "smallvec",
  "snafu",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -847,9 +850,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "linked-hash-map"
@@ -877,15 +880,15 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mime"
@@ -917,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -943,12 +946,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -979,9 +1039,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -999,9 +1059,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -1187,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -1375,22 +1435,23 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "5b9bd29cdffb8875b04f71c51058f940cf4e390bbfd2ce669c4f22cd70b492a5"
 dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1398,15 +1459,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1056a0db1978e9dbf0f6e4fca677f6f9143dc1c19de346f22cac23e422196834"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -1423,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13af2fbb8b60a8950d6c72a56d2095c28870367cc8e10c55e9745bac4995a2c4"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1481,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -1499,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
@@ -1603,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#7fe4205b667fb5975041f20104357f9bdec7e4bc"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#38283c5df040bf82bf2ddc834e9509be6c52ea65"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1624,6 +1685,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "tracing",
@@ -1635,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "stackable-zookeeper-crd"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#fe9aa9ad5a1fbee5ffbc271a09017ec34e6dc1c1"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=adapt_to_operator_pod_name_and_create_config_map#a099695d66b159c68b08b44139164a57de2eda3d"
 dependencies = [
  "k8s-openapi",
  "kube",
@@ -1693,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1782,9 +1845,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1878,6 +1941,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
 dependencies = [
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1927,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -1967,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2004,12 +2068,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -2095,9 +2156,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2107,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2122,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2134,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2144,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2157,15 +2218,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6375dbd828ed6964c3748e4ef6d18e7a175d408ffe184bca01698d0c73f915a9"
+checksum = "ad104641f3c958dab30eb3010e834c2622d1f3f4c530fef1dee20ad9485f3c09"
 dependencies = [
  "dtoa",
  "indexmap",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "stackable-zookeeper-crd"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#ecd6b8f3a9565a9f2c0d1191e0ae220b0be921fa"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=main#2b66283b147e3b5e1ed16ed6d23713db05ded2a4"
 dependencies = [
  "k8s-openapi",
  "kube",

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -9,16 +9,19 @@ version = "0.1.0-nightly"
 [dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "main"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_operator_pod_name_and_create_config_map"}
 
-k8s-openapi = { version = "0.12.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.57", default-features = false, features = ["jsonpatch", "derive"] }
+k8s-openapi = { version = "0.12", default-features = false }
+kube = { version = "0.58", default-features = false, features = ["jsonpatch", "derive"] }
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 strum = "0.21"
 strum_macros = "0.21"
+
+[dev-dependencies]
+k8s-openapi = { version = "0.12", default-features = false, features = ["v1_21"] }
 
 [features]
 default = ["native-tls"]

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0-nightly"
 [dependencies]
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_operator_pod_name_and_create_config_map"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "main"}
 
 k8s-openapi = { version = "0.12", default-features = false }
 kube = { version = "0.58", default-features = false, features = ["jsonpatch", "derive"] }

--- a/examples/simple-nificluster.yaml
+++ b/examples/simple-nificluster.yaml
@@ -15,7 +15,7 @@ spec:
         selector:
           matchLabels:
             kubernetes.io/arch: stackable-linux
-        replicas: 1
+        replicas: 3
         config:
           httpPort: 10000
           protocolPort: 10443

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0-nightly"
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 stackable-nifi-crd = { path = "../crd" }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_operator_pod_name_and_create_config_map"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "main"}
 
 async-trait = "0.1"
 futures = "0.3"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -10,12 +10,12 @@ version = "0.1.0-nightly"
 product-config = { git = "https://github.com/stackabletech/product-config.git", branch = "main" }
 stackable-nifi-crd = { path = "../crd" }
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "main"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_operator_pod_name_and_create_config_map"}
 
 async-trait = "0.1"
 futures = "0.3"
-k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
-kube = { version = "0.57", default-features = false, features = ["jsonpatch"] }
+k8s-openapi = { version = "0.12", default-features = false }
+kube = { version = "0.58", default-features = false, features = ["jsonpatch"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -1,6 +1,6 @@
 use crate::monitoring;
 use std::num::ParseIntError;
-
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, thiserror::Error)]
 pub enum NifiError {
     #[error("Kubernetes reported error: {source}")]
@@ -8,6 +8,23 @@ pub enum NifiError {
         #[from]
         source: kube::Error,
     },
+
+    #[error("NiFi monitoring reported error: {source}")]
+    NifiMonitoringError {
+        #[from]
+        source: monitoring::NifiMonitoringError,
+    },
+
+    #[error(
+        "ConfigMap of type [{cm_type}] is for pod with generate_name [{pod_name}] is missing."
+    )]
+    MissingConfigMapError {
+        cm_type: &'static str,
+        pod_name: String,
+    },
+
+    #[error("ConfigMap of type [{cm_type}] is missing the metadata.name. Maybe the config map was not created yet?")]
+    MissingConfigMapNameError { cm_type: &'static str },
 
     #[error("Error from Operator framework: {source}")]
     OperatorError {
@@ -19,12 +36,6 @@ pub enum NifiError {
     ParseError {
         #[from]
         source: ParseIntError,
-    },
-
-    #[error("NiFi monitoring reported error: {source}")]
-    NifiMonitoringError {
-        #[from]
-        source: monitoring::NifiMonitoringError,
     },
 
     #[error("Reqwest reported error: {source}")]
@@ -39,12 +50,12 @@ pub enum NifiError {
         source: serde_json::Error,
     },
 
+    #[error("Error with ZooKeeper connection. Could not retrieve the ZooKeeper connection. This is a bug. Please open a ticket.")]
+    ZookeeperConnectionInformationError,
+
     #[error("Error from ZooKeeper: {source}")]
     ZookeeperError {
         #[from]
         source: stackable_zookeeper_crd::error::Error,
     },
-
-    #[error("Invalid Configmap. No name found which is required to query the ConfigMap.")]
-    InvalidConfigMap,
 }

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -6,7 +6,6 @@ use crate::config::{
     build_bootstrap_conf, build_nifi_properties, build_state_management_xml,
     validated_product_config,
 };
-use crate::error::NifiError;
 use crate::monitoring::{
     NifiRestClient, ReportingTask, ReportingTaskState, ReportingTaskStatus, NO_TASK_ID,
 };
@@ -14,7 +13,6 @@ use async_trait::async_trait;
 use futures::Future;
 use k8s_openapi::api::core::v1::{ConfigMap, EnvVar, Pod};
 use kube::api::ListParams;
-use kube::error::ErrorResponse;
 use kube::Api;
 use kube::ResourceExt;
 use product_config::types::PropertyNameKind;
@@ -24,7 +22,7 @@ use stackable_nifi_crd::{
     NIFI_CLUSTER_METRICS_PORT, NIFI_CLUSTER_NODE_PROTOCOL_PORT, NIFI_WEB_HTTP_PORT,
 };
 use stackable_operator::builder::{
-    ConfigMapBuilder, ContainerBuilder, ContainerPortBuilder, ObjectMetaBuilder, PodBuilder,
+    ContainerBuilder, ContainerPortBuilder, ObjectMetaBuilder, PodBuilder,
 };
 use stackable_operator::client::Client;
 use stackable_operator::controller::{Controller, ControllerStrategy, ReconciliationState};
@@ -42,7 +40,7 @@ use stackable_operator::reconcile::{
 use stackable_operator::role_utils::{
     get_role_and_group_labels, list_eligible_nodes_for_role_and_group, EligibleNodesForRoleAndGroup,
 };
-use stackable_operator::{k8s_utils, pod_utils, role_utils};
+use stackable_operator::{configmap, k8s_utils, name_utils, role_utils};
 use stackable_zookeeper_crd::util::ZookeeperConnectionInformation;
 use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;
@@ -59,7 +57,7 @@ const PROTOCOL_PORT_NAME: &str = "protocol";
 const LOAD_BALANCE_PORT_NAME: &str = "loadbalance";
 const METRICS_PORT_NAME: &str = "metrics";
 
-const CONTAINER_NAME: &str = "nifi";
+const CONFIG_MAP_TYPE_CONFIG: &str = "config";
 
 type NifiReconcileResult = ReconcileResult<error::NifiError>;
 
@@ -136,52 +134,6 @@ impl NifiState {
         Ok(ReconcileFunctionAction::Done)
     }
 
-    /// Create or update a config map.
-    /// - Create if no config map of that name exists
-    /// - Update if config map exists but the content differs
-    /// - Do nothing if the config map exists and the content is identical
-    /// - Forward any kube errors that may appear
-    // TODO: move to operator-rs
-    async fn create_config_map(&self, config_map: ConfigMap) -> Result<(), NifiError> {
-        let cm_name = match config_map.metadata.name.as_deref() {
-            None => return Err(NifiError::InvalidConfigMap),
-            Some(name) => name,
-        };
-
-        match self
-            .context
-            .client
-            .get::<ConfigMap>(cm_name, Some(&self.context.namespace()))
-            .await
-        {
-            Ok(ConfigMap {
-                data: existing_config_map_data,
-                ..
-            }) if existing_config_map_data == config_map.data => {
-                debug!(
-                    "ConfigMap [{}] already exists with identical data, skipping creation!",
-                    cm_name
-                );
-            }
-            Ok(_) => {
-                debug!(
-                    "ConfigMap [{}] already exists, but differs, updating it!",
-                    cm_name
-                );
-                self.context.client.update(&config_map).await?;
-            }
-            Err(stackable_operator::error::Error::KubeError {
-                source: kube::error::Error::Api(ErrorResponse { reason, .. }),
-            }) if reason == "NotFound" => {
-                debug!("Error getting ConfigMap [{}]: [{:?}]", cm_name, reason);
-                self.context.client.create(&config_map).await?;
-            }
-            Err(e) => return Err(NifiError::OperatorError { source: e }),
-        }
-
-        Ok(())
-    }
-
     async fn create_missing_pods(&mut self) -> NifiReconcileResult {
         // The iteration happens in two stages here, to accommodate the way our operators think
         // about nodes and roles.
@@ -241,24 +193,27 @@ impl NifiState {
                             role_group
                         );
 
-                        let (pod, config_maps) = self
-                            .create_pod_and_config_maps(
-                                &role,
-                                role_group,
-                                node_name,
-                                config_for_role_and_group(
-                                    role_str,
-                                    role_group,
-                                    &self.validated_role_config,
-                                )?,
-                            )
+                        // now we have a node that needs pods -> get validated config
+                        let validated_config = config_for_role_and_group(
+                            role_str,
+                            role_group,
+                            &self.validated_role_config,
+                        )?;
+
+                        let config_maps = self
+                            .create_config_maps(role_str, role_group, node_name, validated_config)
                             .await?;
 
-                        for config_map in config_maps {
-                            self.create_config_map(config_map).await?;
-                        }
+                        self.create_pod(
+                            role_str,
+                            role_group,
+                            node_name,
+                            &config_maps,
+                            validated_config,
+                        )
+                        .await?;
 
-                        self.context.client.create(&pod).await?;
+                        return Ok(ReconcileFunctionAction::Requeue(Duration::from_secs(10)));
                     }
                 }
             }
@@ -266,41 +221,66 @@ impl NifiState {
         Ok(ReconcileFunctionAction::Continue)
     }
 
-    async fn create_pod_and_config_maps(
+    /// Creates the config maps required for a NiFi instance (or role, role_group combination):
+    /// * 'bootstrap.conf'
+    /// * 'nifi.properties'
+    /// * 'state-management.xml'
+    ///
+    /// These three configuration files are collected in one config map for now.
+    ///
+    /// Labels are automatically adapted from the `recommended_labels` with a type (bootstrap,
+    /// properties, state-management). Names are generated via `name_utils::build_resource_name`.
+    ///
+    /// Returns a map with a 'type' identifier (e.g. bootstrap) as key and the corresponding
+    /// ConfigMap as value. This is required to set the volume mounts in the pod later on.
+    ///
+    /// # Arguments
+    ///
+    /// - `role` - The NiFi role.
+    /// - `group` - The role group.
+    /// - `node_name` - The node name for this instance.
+    /// - `validated_config` - The validated product config.
+    ///
+    async fn create_config_maps(
         &self,
-        role: &NifiRole,
-        role_group: &str,
+        role: &str,
+        group: &str,
         node_name: &str,
         validated_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
-    ) -> Result<(Pod, Vec<ConfigMap>), NifiError> {
-        let mut config_maps = vec![];
-        let mut env_vars = vec![];
+    ) -> Result<HashMap<&'static str, ConfigMap>, error::NifiError> {
+        let mut config_maps = HashMap::new();
         let mut cm_data = BTreeMap::new();
-        let mut http_port: Option<&String> = None;
-        let mut protocol_port: Option<&String> = None;
-        let mut load_balance: Option<&String> = None;
-        let mut metrics_port: Option<String> = None;
+
+        let mut cm_labels = get_recommended_labels(
+            &self.context.resource,
+            APP_NAME,
+            &self.context.resource.spec.version.to_string(),
+            role,
+            group,
+        );
 
         for (property_name_kind, config) in validated_config {
-            // we need to convert to <String, String> to <String, Option<String>> to deal with
-            // CLI flags etc. We can not currently represent that via operator-rs / product-config.
-            // This is a preparation for that.
-            let transformed_config: BTreeMap<String, Option<String>> = config
-                .iter()
-                .map(|(k, v)| (k.to_string(), Some(v.to_string())))
-                .collect();
+            let zk_connect_string = match self.zookeeper_info.as_ref() {
+                Some(info) => &info.connection_string,
+                None => return Err(error::NifiError::ZookeeperConnectionInformationError),
+            };
 
-            let zk_connect_string = &self.zookeeper_info.as_ref().unwrap().connection_string;
+            // enhance with config map type label
+            cm_labels.insert(
+                configmap::CONFIGMAP_TYPE_LABEL.to_string(),
+                CONFIG_MAP_TYPE_CONFIG.to_string(),
+            );
 
-            match property_name_kind {
-                PropertyNameKind::File(file_name) => match file_name.as_str() {
+            if let PropertyNameKind::File(file_name) = property_name_kind {
+                match file_name.as_str() {
                     config::NIFI_BOOTSTRAP_CONF => {
                         cm_data.insert(file_name.to_string(), build_bootstrap_conf());
                     }
                     config::NIFI_PROPERTIES => {
-                        http_port = config.get(NIFI_WEB_HTTP_PORT);
-                        protocol_port = config.get(NIFI_CLUSTER_NODE_PROTOCOL_PORT);
-                        load_balance = config.get(NIFI_CLUSTER_LOAD_BALANCE_PORT);
+                        let http_port = config.get(NIFI_WEB_HTTP_PORT);
+
+                        let protocol_port = config.get(NIFI_CLUSTER_NODE_PROTOCOL_PORT);
+                        let load_balance = config.get(NIFI_CLUSTER_LOAD_BALANCE_PORT);
 
                         cm_data.insert(
                             file_name.to_string(),
@@ -327,66 +307,131 @@ impl NifiState {
                         );
                     }
                     _ => {
-                        warn!("Unknown filename [{}] was provided in product config. Possible values are {:?}", 
-                              file_name, vec![config::NIFI_BOOTSTRAP_CONF, config::NIFI_PROPERTIES, config::NIFI_STATE_MANAGEMENT_XML]);
-                    }
-                },
-                PropertyNameKind::Env => {
-                    for (property_name, property_value) in transformed_config {
-                        if property_name.is_empty() {
-                            warn!("Received empty property_name for ENV... skipping");
-                            continue;
-                        }
-
-                        // if a metrics port is provided (for now by user, it is not required in
-                        // product config to be able to not configure any monitoring / metrics)
-                        if property_name == NIFI_CLUSTER_METRICS_PORT {
-                            metrics_port = property_value.clone();
-                            continue;
-                        }
-
-                        env_vars.push(EnvVar {
-                            name: property_name,
-                            value: property_value,
-                            value_from: None,
-                        });
+                        warn ! ("Unknown filename [{}] was provided in product config. Possible values are {:?}",
+                    file_name, vec ! [config::NIFI_BOOTSTRAP_CONF, config::NIFI_PROPERTIES, config::NIFI_STATE_MANAGEMENT_XML]);
                     }
                 }
-                _ => {}
             }
         }
 
-        let pod_name = pod_utils::get_pod_name(
+        let cm_properties_name = name_utils::build_resource_name(
             APP_NAME,
             &self.context.name(),
-            role_group,
-            &role.to_string(),
-            node_name,
+            role,
+            Some(group),
+            Some(node_name),
+            Some(CONFIG_MAP_TYPE_CONFIG),
+        )?;
+
+        let cm_config = configmap::build_config_map(
+            &self.context.resource,
+            &cm_properties_name,
+            &self.context.namespace(),
+            cm_labels,
+            cm_data,
+        )?;
+
+        config_maps.insert(
+            CONFIG_MAP_TYPE_CONFIG,
+            configmap::create_config_map(&self.context.client, cm_config).await?,
         );
 
-        let cm_name = format!("{}-config", pod_name);
+        Ok(config_maps)
+    }
+
+    /// Creates the pod required for the NiFi instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `role` - The NiFi role.
+    /// - `group` - The role group.
+    /// - `node_name` - The node name for this pod.
+    /// - `config_maps` - The config maps and respective types required for this pod.
+    /// - `validated_config` - The validated product config.
+    ///
+    async fn create_pod(
+        &self,
+        role: &str,
+        group: &str,
+        node_name: &str,
+        config_maps: &HashMap<&'static str, ConfigMap>,
+        validated_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
+    ) -> Result<Pod, error::NifiError> {
+        let mut env_vars = vec![];
+        let mut http_port: Option<&String> = None;
+        let mut protocol_port: Option<&String> = None;
+        let mut load_balance: Option<&String> = None;
+        let mut metrics_port: Option<String> = None;
 
         let version = &self.context.resource.spec.version.to_string();
 
-        let labels = get_recommended_labels(
-            &self.context.resource,
-            APP_NAME,
-            version,
-            &role.to_string(),
-            role_group,
-        );
+        // extract container ports from config
+        if let Some(config) =
+            validated_config.get(&PropertyNameKind::File(config::NIFI_PROPERTIES.to_string()))
+        {
+            http_port = config.get(NIFI_WEB_HTTP_PORT);
+            protocol_port = config.get(NIFI_CLUSTER_NODE_PROTOCOL_PORT);
+            load_balance = config.get(NIFI_CLUSTER_LOAD_BALANCE_PORT);
+        }
 
-        let mut container_builder = ContainerBuilder::new(CONTAINER_NAME);
-        container_builder.image(format!("{}:{}", CONTAINER_NAME, version));
+        // extract metric port and env variables from env
+        if let Some(config) = validated_config.get(&PropertyNameKind::Env) {
+            for (property_name, property_value) in config {
+                if property_name.is_empty() {
+                    warn!("Received empty property_name for ENV... skipping");
+                    continue;
+                }
+
+                if property_name == NIFI_CLUSTER_METRICS_PORT {
+                    metrics_port = Some(property_value.clone());
+                    continue;
+                }
+
+                env_vars.push(EnvVar {
+                    name: property_name.clone(),
+                    value: Some(property_value.clone()),
+                    value_from: None,
+                });
+            }
+        }
+
+        let pod_name = name_utils::build_resource_name(
+            APP_NAME,
+            &self.context.name(),
+            role,
+            Some(group),
+            Some(node_name),
+            None,
+        )?;
+
+        let labels = get_recommended_labels(&self.context.resource, APP_NAME, version, role, group);
+
+        let mut container_builder = ContainerBuilder::new(APP_NAME);
+        container_builder.image(format!("{}:{}", APP_NAME, version));
         container_builder.command(build_nifi_start_command(&self.context.resource.spec));
-        // TODO: For now we set the mount path to the NiFi package config folder.
-        //   This needs to be investigated and changed into an separate config folder.
-        //   Related to: https://issues.apache.org/jira/browse/NIFI-5573
-        container_builder.add_configmapvolume(
-            cm_name.clone(),
-            format!("{}/nifi-{}/conf", "{{packageroot}}", version),
-        );
         container_builder.add_env_vars(env_vars);
+
+        // One mount for the config directory
+        if let Some(config_map_data) = config_maps.get(CONFIG_MAP_TYPE_CONFIG) {
+            if let Some(name) = config_map_data.metadata.name.as_ref() {
+                // TODO: For now we set the mount path to the NiFi package config folder.
+                //   This needs to be investigated and changed into an separate config folder.
+                //   Related to: https://issues.apache.org/jira/browse/NIFI-5573
+                container_builder.add_configmapvolume(
+                    name,
+                    format!("{}/nifi-{}/conf", "{{packageroot}}", version),
+                );
+            } else {
+                return Err(error::NifiError::MissingConfigMapNameError {
+                    cm_type: CONFIG_MAP_TYPE_CONFIG,
+                });
+            }
+        } else {
+            return Err(error::NifiError::MissingConfigMapError {
+                cm_type: CONFIG_MAP_TYPE_CONFIG,
+                pod_name,
+            });
+        }
 
         if let Some(port) = http_port {
             container_builder.add_container_port(
@@ -426,7 +471,7 @@ impl NifiState {
         let pod = PodBuilder::new()
             .metadata(
                 ObjectMetaBuilder::new()
-                    .name(pod_name)
+                    .generate_name(pod_name)
                     .namespace(&self.context.client.default_namespace)
                     .with_labels(labels)
                     .with_annotations(annotations)
@@ -438,24 +483,7 @@ impl NifiState {
             .node_name(node_name)
             .build()?;
 
-        config_maps.push(
-            ConfigMapBuilder::new()
-                .metadata(
-                    ObjectMetaBuilder::new()
-                        .name(cm_name)
-                        .ownerreference_from_resource(
-                            &self.context.resource,
-                            Some(true),
-                            Some(true),
-                        )?
-                        .namespace(&self.context.client.default_namespace)
-                        .build()?,
-                )
-                .data(cm_data)
-                .build()?,
-        );
-
-        Ok((pod, config_maps))
+        Ok(self.context.client.create(&pod).await?)
     }
 
     /// In order to enable / disable monitoring for NiFi, we have to make several REST calls.

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -418,7 +418,7 @@ impl NifiState {
                 //   Related to: https://issues.apache.org/jira/browse/NIFI-5573
                 container_builder.add_configmapvolume(
                     name,
-                    format!("{}/nifi-{}/conf", "{{packageroot}}", version),
+                    format!("{{{{packageroot}}}}/nifi-{}/conf", version),
                 );
             } else {
                 return Err(error::NifiError::MissingConfigMapNameError {

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -193,7 +193,7 @@ impl NifiState {
                             role_group
                         );
 
-                        // now we have a node that needs pods -> get validated config
+                        // now we have a node that needs a pod -> get validated config
                         let validated_config = config_for_role_and_group(
                             role_str,
                             role_group,
@@ -278,7 +278,6 @@ impl NifiState {
                     }
                     config::NIFI_PROPERTIES => {
                         let http_port = config.get(NIFI_WEB_HTTP_PORT);
-
                         let protocol_port = config.get(NIFI_CLUSTER_NODE_PROTOCOL_PORT);
                         let load_balance = config.get(NIFI_CLUSTER_LOAD_BALANCE_PORT);
 
@@ -307,8 +306,8 @@ impl NifiState {
                         );
                     }
                     _ => {
-                        warn ! ("Unknown filename [{}] was provided in product config. Possible values are {:?}",
-                    file_name, vec ! [config::NIFI_BOOTSTRAP_CONF, config::NIFI_PROPERTIES, config::NIFI_STATE_MANAGEMENT_XML]);
+                        warn!("Unknown filename [{}] was provided in product config. Possible values are {:?}",
+                              file_name, vec![config::NIFI_BOOTSTRAP_CONF, config::NIFI_PROPERTIES, config::NIFI_STATE_MANAGEMENT_XML]);
                     }
                 }
             }

--- a/operator/src/monitoring.rs
+++ b/operator/src/monitoring.rs
@@ -1,4 +1,4 @@
-use crate::{CONTAINER_NAME, HTTP_PORT_NAME};
+use crate::{APP_NAME, HTTP_PORT_NAME};
 use k8s_openapi::api::core::v1::{Container, Pod};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Response;
@@ -515,8 +515,7 @@ fn nifi_rest_endpoint(pod: &Pod) -> Result<NifiRestEndpoint, NifiMonitoringError
         Some(name) => name,
     };
 
-    let http_port =
-        find_pod_container_port(spec.containers.as_slice(), CONTAINER_NAME, HTTP_PORT_NAME)?;
+    let http_port = find_pod_container_port(spec.containers.as_slice(), APP_NAME, HTTP_PORT_NAME)?;
 
     Ok(NifiRestEndpoint {
         node_name: node_name.clone(),


### PR DESCRIPTION
## Description
- Split create_pod_and_config_maps into create_pod and create_config_maps
- Using operator-rs build_config_map and create_config_map
- Using operator-rs build_resource_name for pods and config maps.
- Bumped kube-rs to 0.58

Related: [10](https://github.com/stackabletech/issues/issues/10)

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
