### PR TITLE
[Merged by Bors] - Support specifying a namespace to watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Reconciliation errors are now reported as Kubernetes events ([#218]).
+- Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
+  a single namespace to watch ([#223]).
 
 ### Changed
 
-- `operator-rs` `0.10.0` -> `0.12.0` ([#218]).
+- `operator-rs` `0.10.0` -> `0.13.0` ([#218],[#223]).
 
 [#218]: https://github.com/stackabletech/nifi-operator/pull/218
+[#223]: https://github.com/stackabletech/nifi-operator/pull/223
 
 ## [0.5.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1536,8 +1536,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "stackable-operator",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
  "tracing",
  "xml-rs",
 ]
@@ -1560,16 +1559,15 @@ dependencies = [
  "snafu",
  "stackable-nifi-crd",
  "stackable-operator",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "stackable-operator"
-version = "0.12.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.12.0#ac525b91421f7b0d4c74462627bf13e59be5661b"
+version = "0.13.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
 dependencies = [
  "backoff",
  "chrono",
@@ -1589,7 +1587,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
+ "strum 0.23.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -1608,7 +1606,16 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+dependencies = [
+ "strum_macros 0.24.0",
 ]
 
 [[package]]
@@ -1618,6 +1625,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,3 @@
-* xref:building.adoc[]
 * xref:dependencies.adoc[]
 * xref:installation.adoc[]
 * xref:configuration.adoc[]

--- a/docs/modules/ROOT/pages/building.adoc
+++ b/docs/modules/ROOT/pages/building.adoc
@@ -1,7 +1,0 @@
-= Building the Operator
-
-This operator is written in Rust.
-
-It is developed against the latest stable Rust release, and we currently don't support any older versions.
-
-    cargo build

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,9 +1,28 @@
 
-=== Command Line Arguments
+=== product-config
 
-The operator accepts the following commands:
+*Default value*: `/etc/stackable/nifi-operator/config-spec/properties.yaml`
 
-*run*: Run the operator and start deploying pods.
+*Required*: false
 
-*crd*: Print the current version of CRDs which the operator requires to be deployed to Kubernetes.
+*Multiple values:* false
 
+[source]
+----
+cargo run -- run --product-config /foo/bar/properties.yaml
+----
+
+=== watch-namespace
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+cargo run -- run --watch-namespace test
+----

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -9,7 +9,7 @@
 
 [source]
 ----
-cargo run -- run --product-config /foo/bar/properties.yaml
+stackable-nifi-operator run --product-config /foo/bar/properties.yaml
 ----
 
 === watch-namespace
@@ -24,5 +24,5 @@ The operator will **only** watch for resources in the provided namespace `test`:
 
 [source]
 ----
-cargo run -- run --watch-namespace test
+stackable-nifi-operator run --watch-namespace test
 ----

--- a/docs/modules/ROOT/pages/config_properties.adoc
+++ b/docs/modules/ROOT/pages/config_properties.adoc
@@ -1,4 +1,4 @@
-== Kubernetes custom resource options
+
 The cluster can be configured via a YAML file. This custom resource specifies the amount of replicas for each role group or role specific configuration like port definitions etc.
 The following listing shows a fairly complete example that sets most available options, for more detail about the individual elements please refer to the table further down on the page.
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,8 +1,17 @@
 = Configuration
 
 == Command Line Parameters
+
 This operator accepts the following command line parameters:
 
 include::commandline_args.adoc[]
+
+== Environment variables
+
+This operator accepts the following environment variables:
+
+include::env_var_args.adoc[]
+
+== Kubernetes custom resource options
 
 include::config_properties.adoc[]

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -10,7 +10,7 @@
 [source]
 ----
 export PRODUCT_CONFIG=/foo/bar/properties.yaml
-cargo run -- run
+stackable-nifi-operator run
 ----
 
 or via docker:
@@ -38,7 +38,7 @@ The operator will **only** watch for resources in the provided namespace `test`:
 [source]
 ----
 export WATCH_NAMESPACE=test
-cargo run -- run
+stackable-nifi-operator run
 ----
 
 or via docker:

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -1,0 +1,56 @@
+
+=== PRODUCT_CONFIG
+
+*Default value*: `/etc/stackable/nifi-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+[source]
+----
+export PRODUCT_CONFIG=/foo/bar/properties.yaml
+cargo run -- run
+----
+
+or via docker:
+
+----
+docker run \
+    --name nifi-operator \
+    --network host \
+    --env KUBECONFIG=/home/stackable/.kube/config \
+    --env PRODUCT_CONFIG=/my/product/config.yaml \
+    --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+    docker.stackable.tech/stackable/nifi-operator:latest
+----
+
+=== WATCH_NAMESPACE
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+export WATCH_NAMESPACE=test
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name nifi-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env WATCH_NAMESPACE=test \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/nifi-operator:latest
+----
+

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -13,8 +13,7 @@ serde = "1.0"
 serde_json = "1.0"
 snafu = "0.7"
 rand = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
-strum = { version = "0.23", features = ["derive"] }
-strum_macros = "0.23"
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+strum = { version = "0.24", features = ["derive"] }
 tracing = "0.1"
 

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.6.0-nightly"
 
 [dependencies]
 anyhow = "1.0"
-clap = "3.0"
+clap = "3.1"
 fnv = "1.0"
 futures = { version = "0.3", features = ["compat"] }
 pin-project = "1.0"
@@ -20,14 +20,13 @@ serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 stackable-nifi-crd = { path = "../crd" }
-strum = "0.23"
-strum_macros = "0.23"
+strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.17", features = ["full"] }
 tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 stackable-nifi-crd = { path = "../crd" }

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -10,8 +10,7 @@ use stackable_operator::product_config_utils::{
 };
 use stackable_operator::role_utils::Role;
 use std::collections::{BTreeMap, HashMap};
-use strum_macros::Display;
-use strum_macros::EnumIter;
+use strum::{Display, EnumIter};
 
 pub const NIFI_BOOTSTRAP_CONF: &str = "bootstrap.conf";
 pub const NIFI_PROPERTIES: &str = "nifi.properties";

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -979,13 +979,12 @@ async fn get_proxy_hosts(
     // take all published addresses for now to be on the safe side.
     let mut proxy_setting = cluster_nodes
         .into_iter()
-        .map(|node| {
+        .flat_map(|node| {
             node.status
                 .unwrap_or_default()
                 .addresses
                 .unwrap_or_default()
         })
-        .flatten()
         .collect::<Vec<NodeAddress>>()
         .iter()
         .map(|node_address| format!("{}:{}", node_address.address, external_port))


### PR DESCRIPTION
## Description

try
```
cargo run -- run --watch-namespace test
```
or
```
export WATCH_NAMESPACE=test
cargo run -- run
```

fixes https://github.com/stackabletech/nifi-operator/issues/214

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
