### PR TITLE
[Merged by Bors] - Fixed java heap settings

### DIFF
--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -88,8 +88,8 @@ pub fn build_bootstrap_conf(
         );
 
         // Push heap size config as max and min size to java args
-        java_args.push(format!("--Xmx{}m", heap_size));
-        java_args.push(format!("--Xms{}m", heap_size));
+        java_args.push(format!("-Xmx{}m", heap_size));
+        java_args.push(format!("-Xms{}m", heap_size));
     } else {
         tracing::debug!("No memory limits defined");
     }


### PR DESCRIPTION
# Description
We accidentally merged broken Java heap settings that use -- instead of - and caused the pods to never start.


*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
