### PR TITLE
[Merged by Bors] - Fix Asciidoc warnings by making each document self-contained

### DIFF
--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,3 +1,6 @@
+== Command Line Parameters
+
+This operator accepts the following command line parameters:
 
 === product-config
 

--- a/docs/modules/ROOT/pages/config_properties.adoc
+++ b/docs/modules/ROOT/pages/config_properties.adoc
@@ -1,3 +1,4 @@
+== Kubernetes custom resource options
 
 The cluster can be configured via a YAML file. This custom resource specifies the amount of replicas for each role group or role specific configuration like port definitions etc.
 The following listing shows a fairly complete example that sets most available options, for more detail about the individual elements please refer to the table further down on the page.

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,17 +1,7 @@
 = Configuration
 
-== Command Line Parameters
-
-This operator accepts the following command line parameters:
-
 include::commandline_args.adoc[]
 
-== Environment variables
-
-This operator accepts the following environment variables:
-
 include::env_var_args.adoc[]
-
-== Kubernetes custom resource options
 
 include::config_properties.adoc[]

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -1,3 +1,6 @@
+== Environment variables
+
+This operator accepts the following environment variables:
 
 === PRODUCT_CONFIG
 


### PR DESCRIPTION
# Description

This fixes this warning:

```
[19:27:52.427] WARN (asciidoctor): section title out of sequence: expected level 1, got level 2
    file: docs/modules/ROOT/pages/config_properties.adoc:82
    source: https://github.com/stackabletech/nifi-operator.git (refname: main, start path: docs)
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
