### PR TITLE
[Merged by Bors] - Fix a regression that made PVC configs mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed a regression that made PVC configs mandatory in some cases ([#375]).
+
+[#375]: https://github.com/stackabletech/nifi-operator/pull/375
+
 ## [0.8.0] - 2022-11-08
 
 ### Added

--- a/deploy/crd/nificluster.crd.yaml
+++ b/deploy/crd/nificluster.crd.yaml
@@ -228,6 +228,8 @@ spec:
                           storage:
                             properties:
                               contentRepo:
+                                default:
+                                  capacity: null
                                 properties:
                                   capacity:
                                     description: |-
@@ -300,6 +302,8 @@ spec:
                                     type: string
                                 type: object
                               databaseRepo:
+                                default:
+                                  capacity: null
                                 properties:
                                   capacity:
                                     description: |-
@@ -372,6 +376,8 @@ spec:
                                     type: string
                                 type: object
                               flowfileRepo:
+                                default:
+                                  capacity: null
                                 properties:
                                   capacity:
                                     description: |-
@@ -444,6 +450,8 @@ spec:
                                     type: string
                                 type: object
                               provenanceRepo:
+                                default:
+                                  capacity: null
                                 properties:
                                   capacity:
                                     description: |-
@@ -516,6 +524,8 @@ spec:
                                     type: string
                                 type: object
                               stateRepo:
+                                default:
+                                  capacity: null
                                 properties:
                                   capacity:
                                     description: |-
@@ -587,12 +597,6 @@ spec:
                                     nullable: true
                                     type: string
                                 type: object
-                            required:
-                            - contentRepo
-                            - databaseRepo
-                            - flowfileRepo
-                            - provenanceRepo
-                            - stateRepo
                             type: object
                         type: object
                     type: object
@@ -754,6 +758,8 @@ spec:
                                 storage:
                                   properties:
                                     contentRepo:
+                                      default:
+                                        capacity: null
                                       properties:
                                         capacity:
                                           description: |-
@@ -826,6 +832,8 @@ spec:
                                           type: string
                                       type: object
                                     databaseRepo:
+                                      default:
+                                        capacity: null
                                       properties:
                                         capacity:
                                           description: |-
@@ -898,6 +906,8 @@ spec:
                                           type: string
                                       type: object
                                     flowfileRepo:
+                                      default:
+                                        capacity: null
                                       properties:
                                         capacity:
                                           description: |-
@@ -970,6 +980,8 @@ spec:
                                           type: string
                                       type: object
                                     provenanceRepo:
+                                      default:
+                                        capacity: null
                                       properties:
                                         capacity:
                                           description: |-
@@ -1042,6 +1054,8 @@ spec:
                                           type: string
                                       type: object
                                     stateRepo:
+                                      default:
+                                        capacity: null
                                       properties:
                                         capacity:
                                           description: |-
@@ -1113,12 +1127,6 @@ spec:
                                           nullable: true
                                           type: string
                                       type: object
-                                  required:
-                                  - contentRepo
-                                  - databaseRepo
-                                  - flowfileRepo
-                                  - provenanceRepo
-                                  - stateRepo
                                   type: object
                               type: object
                           type: object

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -230,6 +230,8 @@ spec:
                             storage:
                               properties:
                                 contentRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -302,6 +304,8 @@ spec:
                                       type: string
                                   type: object
                                 databaseRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -374,6 +378,8 @@ spec:
                                       type: string
                                   type: object
                                 flowfileRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -446,6 +452,8 @@ spec:
                                       type: string
                                   type: object
                                 provenanceRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -518,6 +526,8 @@ spec:
                                       type: string
                                   type: object
                                 stateRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -589,12 +599,6 @@ spec:
                                       nullable: true
                                       type: string
                                   type: object
-                              required:
-                                - contentRepo
-                                - databaseRepo
-                                - flowfileRepo
-                                - provenanceRepo
-                                - stateRepo
                               type: object
                           type: object
                       type: object
@@ -756,6 +760,8 @@ spec:
                                   storage:
                                     properties:
                                       contentRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -828,6 +834,8 @@ spec:
                                             type: string
                                         type: object
                                       databaseRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -900,6 +908,8 @@ spec:
                                             type: string
                                         type: object
                                       flowfileRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -972,6 +982,8 @@ spec:
                                             type: string
                                         type: object
                                       provenanceRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -1044,6 +1056,8 @@ spec:
                                             type: string
                                         type: object
                                       stateRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -1115,12 +1129,6 @@ spec:
                                             nullable: true
                                             type: string
                                         type: object
-                                    required:
-                                      - contentRepo
-                                      - databaseRepo
-                                      - flowfileRepo
-                                      - provenanceRepo
-                                      - stateRepo
                                     type: object
                                 type: object
                             type: object

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -231,6 +231,8 @@ spec:
                             storage:
                               properties:
                                 contentRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -303,6 +305,8 @@ spec:
                                       type: string
                                   type: object
                                 databaseRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -375,6 +379,8 @@ spec:
                                       type: string
                                   type: object
                                 flowfileRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -447,6 +453,8 @@ spec:
                                       type: string
                                   type: object
                                 provenanceRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -519,6 +527,8 @@ spec:
                                       type: string
                                   type: object
                                 stateRepo:
+                                  default:
+                                    capacity: null
                                   properties:
                                     capacity:
                                       description: |-
@@ -590,12 +600,6 @@ spec:
                                       nullable: true
                                       type: string
                                   type: object
-                              required:
-                                - contentRepo
-                                - databaseRepo
-                                - flowfileRepo
-                                - provenanceRepo
-                                - stateRepo
                               type: object
                           type: object
                       type: object
@@ -757,6 +761,8 @@ spec:
                                   storage:
                                     properties:
                                       contentRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -829,6 +835,8 @@ spec:
                                             type: string
                                         type: object
                                       databaseRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -901,6 +909,8 @@ spec:
                                             type: string
                                         type: object
                                       flowfileRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -973,6 +983,8 @@ spec:
                                             type: string
                                         type: object
                                       provenanceRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -1045,6 +1057,8 @@ spec:
                                             type: string
                                         type: object
                                       stateRepo:
+                                        default:
+                                          capacity: null
                                         properties:
                                           capacity:
                                             description: |-
@@ -1116,12 +1130,6 @@ spec:
                                             nullable: true
                                             type: string
                                         type: object
-                                    required:
-                                      - contentRepo
-                                      - databaseRepo
-                                      - flowfileRepo
-                                      - provenanceRepo
-                                      - stateRepo
                                     type: object
                                 type: object
                             type: object

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -258,15 +258,15 @@ pub enum LogLevel {
     serde(rename_all = "camelCase")
 )]
 pub struct NifiStorageConfig {
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub flowfile_repo: PvcConfig,
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub provenance_repo: PvcConfig,
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub database_repo: PvcConfig,
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub content_repo: PvcConfig,
-    #[serde(default)]
+    #[fragment_attrs(serde(default))]
     pub state_repo: PvcConfig,
 }
 


### PR DESCRIPTION
# Description

This was introduced in #371, when I fragmentified the cluster resources without adding moving the `#[serde(default)]` attributes into `#[fragment_attrs]` blocks.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
