### PR TITLE
[Merged by Bors] - Removed tools image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ All notable changes to this project will be documented in this file.
 - Updated operator-rs to 0.27.1 ([#382])
 - Do not run init container as root anymore and avoid chmod and chown ([#390])
 - [BREAKING] Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#394])
+- [BREAKING]: Removed tools image (reporting task job and init container) and replaced with NiFi product image. This means the latest stackable version has to be used in the product image selection ([#xxx])
+
 
 [#382]: https://github.com/stackabletech/nifi-operator/pull/382
 [#390]: https://github.com/stackabletech/nifi-operator/pull/390
 [#394]: https://github.com/stackabletech/nifi-operator/pull/394
+[#xxx]: https://github.com/stackabletech/nifi-operator/pull/xxx
 
 ## [0.8.1] - 2022-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ All notable changes to this project will be documented in this file.
 - Updated operator-rs to 0.27.1 ([#382])
 - Do not run init container as root anymore and avoid chmod and chown ([#390])
 - [BREAKING] Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#394])
-- [BREAKING]: Removed tools image (reporting task job and init container) and replaced with NiFi product image. This means the latest stackable version has to be used in the product image selection ([#xxx])
-
+- [BREAKING]: Removed tools image (reporting task job and init container) and replaced with NiFi product image. This means the latest stackable version has to be used in the product image selection ([#397])
 
 [#382]: https://github.com/stackabletech/nifi-operator/pull/382
 [#390]: https://github.com/stackabletech/nifi-operator/pull/390
 [#394]: https://github.com/stackabletech/nifi-operator/pull/394
-[#xxx]: https://github.com/stackabletech/nifi-operator/pull/xxx
+[#397]: https://github.com/stackabletech/nifi-operator/pull/397
 
 ## [0.8.1] - 2022-11-10
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -19,7 +19,7 @@ metadata:
 spec:
   image:
     productVersion: 1.18.0 # <2>
-    stackableVersion: 0.2.0
+    stackableVersion: 0.3.0
   zookeeperConfigMapName: simple-nifi-znode # <3>
   config:
     authentication:
@@ -139,7 +139,7 @@ metadata:
 spec:
   image:
     productVersion: 1.16.3 # <1>
-    stackableVersion: 0.2.0 # <2>
+    stackableVersion: 0.3.0 # <2>
   zookeeperConfigMapName: simple-nifi-znode
   config:
     authentication:

--- a/docs/modules/ROOT/partials/config_properties.adoc
+++ b/docs/modules/ROOT/partials/config_properties.adoc
@@ -12,7 +12,7 @@ metadata:
 spec:
   image:
     productVersion: 1.18.0
-    stackableVersion: 0.2.0
+    stackableVersion: 0.3.0
   zookeeperConfigMapName: simple-nifi-znode
   authenticationConfig:
     method:

--- a/docs/modules/getting_started/examples/code/getting-started.sh
+++ b/docs/modules/getting_started/examples/code/getting-started.sh
@@ -112,7 +112,7 @@ metadata:
 spec:
   image:
     productVersion: 1.18.0
-    stackableVersion: 0.2.0
+    stackableVersion: 0.3.0
   zookeeperConfigMapName: simple-nifi-znode
   config:
     authentication:

--- a/docs/modules/getting_started/examples/code/getting-started.sh.j2
+++ b/docs/modules/getting_started/examples/code/getting-started.sh.j2
@@ -112,7 +112,7 @@ metadata:
 spec:
   image:
     productVersion: 1.18.0
-    stackableVersion: 0.2.0
+    stackableVersion: 0.3.0
   zookeeperConfigMapName: simple-nifi-znode
   config:
     authentication:

--- a/examples/simple-nifi-cluster.yaml
+++ b/examples/simple-nifi-cluster.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   image:
     productVersion: 1.18.0
-    stackableVersion: 0.2.0
+    stackableVersion: 0.3.0
   zookeeperConfigMapName: simple-nifi-znode
   config:
     authentication:

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -58,7 +58,6 @@ use tracing::Instrument;
 
 pub const CONTROLLER_NAME: &str = "nificluster";
 
-const STACKABLE_TOOLS_IMAGE: &str = "docker.stackable.tech/stackable/tools:0.2.0-stackable0.4.0";
 const KEYSTORE_VOLUME_NAME: &str = "keystore";
 const KEYSTORE_NIFI_CONTAINER_MOUNT: &str = "/stackable/keystore";
 const KEYSTORE_REPORTING_TASK_MOUNT: &str = "/stackable/cert";
@@ -66,7 +65,7 @@ const KEYSTORE_REPORTING_TASK_MOUNT: &str = "/stackable/cert";
 const DOCKER_IMAGE_BASE_NAME: &str = "nifi";
 
 pub struct Ctx {
-    pub client: stackable_operator::client::Client,
+    pub client: Client,
     pub product_config: ProductConfigManager,
 }
 
@@ -804,9 +803,7 @@ async fn build_node_rolegroup_statefulset(
         .with_context(|_| IllegalContainerNameSnafu {
             container_name: APP_NAME.to_string(),
         })?
-        // TODO: replace with NiFi image
-        //.image_from_product_image(resolved_product_image)
-        .image(STACKABLE_TOOLS_IMAGE)
+        .image_from_product_image(resolved_product_image)
         .command(vec![
             "/bin/bash".to_string(),
             "-c".to_string(),
@@ -1106,7 +1103,7 @@ async fn build_reporting_task_job(
     );
 
     let args = vec![
-        "python/create_nifi_reporting_task.py".to_string(),
+        "/stackable/python/create_nifi_reporting_task.py".to_string(),
         format!("-n {nifi_connect_url}"),
         // In case of the username being simple (e.g. admin) just use it as is
         // If the username is a bind dn (e.g. cn=integrationtest,ou=users,dc=example,dc=org) we have to extract the cn/dn/uid (in this case integrationtest)
@@ -1122,9 +1119,7 @@ async fn build_reporting_task_job(
         .with_context(|_| IllegalContainerNameSnafu {
             container_name: APP_NAME.to_string(),
         })?
-        // TODO: replace with NiFi image
-        //.image_from_product_image(resolved_product_image)
-        .image(STACKABLE_TOOLS_IMAGE)
+        .image_from_product_image(resolved_product_image)
         .command(vec!["sh".to_string(), "-c".to_string()])
         .args(vec![args.join(" ")])
         // The VolumeMount for the secret operator key store certificates

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -11,16 +11,16 @@ dimensions:
       - 3.8.0-stackable0.8.0
   - name: nifi
     values:
-      - 1.15.3-stackable0.2.0
-      - 1.16.3-stackable0.2.0
-      - 1.18.0-stackable0.2.0
+      - 1.15.3-stackable0.3.0
+      - 1.16.3-stackable0.3.0
+      - 1.18.0-stackable0.3.0
   - name: nifi_old
     values:
-      - 1.15.3-stackable0.2.0
-      - 1.16.3-stackable0.2.0
+      - 1.15.3-stackable0.3.0
+      - 1.16.3-stackable0.3.0
   - name: nifi_new
     values:
-      - 1.18.0-stackable0.2.0
+      - 1.18.0-stackable0.3.0
   - name: ldap-use-tls
     values:
       - "false"


### PR DESCRIPTION
# Description

Removed tools image. Working locally with locally build docker image.

Blocked by:  https://github.com/stackabletech/docker-images/pull/266

TODO:

- [x] Adapt stackable versions after new tags are build

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
