### PR TITLE
[Merged by Bors] - Consolidate global config and fragmented NiFi config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - [BREAKING]: Removed tools image (reporting task job and init container) and replaced with NiFi product image. This means the latest stackable version has to be used in the product image selection ([#397])
 - Fixed the RoleGroup `selector`. It was not used before. ([#401])
 - Refactoring of authentication handling ([#408])
+- [BREAKING]: Renamed global `config` to `clusterConfig` ([#417])
+- [BREAKING]: Moved `zookeeper_configmap_name` to `clusterConfig` ([#417])
 
 [#382]: https://github.com/stackabletech/nifi-operator/pull/382
 [#390]: https://github.com/stackabletech/nifi-operator/pull/390
@@ -19,6 +21,7 @@ All notable changes to this project will be documented in this file.
 [#397]: https://github.com/stackabletech/nifi-operator/pull/397
 [#401]: https://github.com/stackabletech/nifi-operator/pull/401
 [#408]: https://github.com/stackabletech/nifi-operator/pull/408
+[#417]: https://github.com/stackabletech/nifi-operator/pull/417
 
 ## [0.8.1] - 2022-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- [BREAKING]: Renamed global `config` to `clusterConfig` ([#417])
+- [BREAKING]: Moved `zookeeper_configmap_name` to `clusterConfig` ([#417])
+
+[#417]: https://github.com/stackabletech/nifi-operator/pull/417
+
+## [23.1.0] - 2023-01-23
+
+### Changed
+
 - Updated operator-rs to 0.31.0 ([#382], [#401], [#408])
 - Do not run init container as root anymore and avoid chmod and chown ([#390])
 - [BREAKING] Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#394])
 - [BREAKING]: Removed tools image (reporting task job and init container) and replaced with NiFi product image. This means the latest stackable version has to be used in the product image selection ([#397])
 - Fixed the RoleGroup `selector`. It was not used before. ([#401])
 - Refactoring of authentication handling ([#408])
-- [BREAKING]: Renamed global `config` to `clusterConfig` ([#417])
-- [BREAKING]: Moved `zookeeper_configmap_name` to `clusterConfig` ([#417])
 
 [#382]: https://github.com/stackabletech/nifi-operator/pull/382
 [#390]: https://github.com/stackabletech/nifi-operator/pull/390
@@ -21,7 +28,6 @@ All notable changes to this project will be documented in this file.
 [#397]: https://github.com/stackabletech/nifi-operator/pull/397
 [#401]: https://github.com/stackabletech/nifi-operator/pull/401
 [#408]: https://github.com/stackabletech/nifi-operator/pull/408
-[#417]: https://github.com/stackabletech/nifi-operator/pull/417
 
 ## [0.8.1] - 2022-11-10
 

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -24,7 +24,7 @@ spec:
           properties:
             spec:
               properties:
-                config:
+                clusterConfig:
                   description: Global Nifi config for e.g. authentication or sensitive properties
                   properties:
                     authentication:
@@ -79,9 +79,13 @@ spec:
                       required:
                         - keySecret
                       type: object
+                    zookeeperConfigMapName:
+                      description: The reference to the ZooKeeper cluster
+                      type: string
                   required:
                     - authentication
                     - sensitiveProperties
+                    - zookeeperConfigMapName
                   type: object
                 image:
                   anyOf:
@@ -148,11 +152,29 @@ spec:
                                 - WARN
                                 - ERROR
                                 - FATAL
-                              nullable: true
                               type: string
+                          required:
+                            - rootLogLevel
                           type: object
                         resources:
-                          nullable: true
+                          default:
+                            memory:
+                              limit: null
+                              runtimeLimits: {}
+                            cpu:
+                              min: null
+                              max: null
+                            storage:
+                              flowfileRepo:
+                                capacity: null
+                              provenanceRepo:
+                                capacity: null
+                              databaseRepo:
+                                capacity: null
+                              contentRepo:
+                                capacity: null
+                              stateRepo:
+                                capacity: null
                           properties:
                             cpu:
                               default:
@@ -430,11 +452,29 @@ spec:
                                       - WARN
                                       - ERROR
                                       - FATAL
-                                    nullable: true
                                     type: string
+                                required:
+                                  - rootLogLevel
                                 type: object
                               resources:
-                                nullable: true
+                                default:
+                                  memory:
+                                    limit: null
+                                    runtimeLimits: {}
+                                  cpu:
+                                    min: null
+                                    max: null
+                                  storage:
+                                    flowfileRepo:
+                                      capacity: null
+                                    provenanceRepo:
+                                      capacity: null
+                                    databaseRepo:
+                                      capacity: null
+                                    contentRepo:
+                                      capacity: null
+                                    stateRepo:
+                                      capacity: null
                                 properties:
                                   cpu:
                                     default:
@@ -736,13 +776,9 @@ spec:
                   description: Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)
                   nullable: true
                   type: boolean
-                zookeeperConfigMapName:
-                  description: The reference to the ZooKeeper cluster
-                  type: string
               required:
-                - config
+                - clusterConfig
                 - image
-                - zookeeperConfigMapName
               type: object
             status:
               nullable: true

--- a/docs/modules/ROOT/partials/config_properties.adoc
+++ b/docs/modules/ROOT/partials/config_properties.adoc
@@ -13,14 +13,18 @@ spec:
   image:
     productVersion: 1.18.0
     stackableVersion: 0.3.0
-  zookeeperConfigMapName: simple-nifi-znode
-  authenticationConfig:
-    method:
-      SingleUser:
-        adminCredentialsSecret:
-          name: nifi-admin-credentials-simple
-          namespace: default
-    allowAnonymousAccess: true
+  clusterConfig:
+    authentication:
+      method:
+        SingleUser:
+          adminCredentialsSecret:
+            name: nifi-admin-credentials-simple
+            namespace: default
+      allowAnonymousAccess: true
+    sensitiveProperties:
+      keySecret: nifi-sensitive-property-key
+      autoGenerate: true
+    zookeeperConfigMapName: simple-nifi-znode
   nodes:
     roleGroups:
       default:
@@ -28,7 +32,6 @@ spec:
           matchLabels:
             kubernetes.io/os: linux
         config:
-          sensitivePropertyKeySecret: nifi-sensitive-property-key
           log:
             rootLogLevel: INFO
         replicas: 3
@@ -38,14 +41,14 @@ spec:
 
 [source,yaml]
 ----
- nodes:
-    roleGroups:
-      default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
-        config:
-        replicas: 3
+nodes:
+  roleGroups:
+    default:
+      selector:
+        matchLabels:
+          kubernetes.io/os: linux
+      config: {}
+      replicas: 3
 ----
 The `nodes` element is used to define how many pods with which configuration should be rolled out.
 It is possible to define multiple groups of nodes, each with its own distinct configuration, every `roleGroup` has the following elements:
@@ -58,7 +61,8 @@ It is possible to define multiple groups of nodes, each with its own distinct co
 
 [source,yaml]
 ----
-  authenticationConfig:
+clusterConfig:
+  authentication:
     method:
       SingleUser:
         adminCredentialsSecret:
@@ -66,7 +70,7 @@ It is possible to define multiple groups of nodes, each with its own distinct co
           namespace: default
     allowAnonymousAccess: true
 ----
-All authentication related parameters are configured in the authenticationConfig element.
+All authentication related parameters are configured in the `authentication` element.
 
 ==== Authentication Method
 
@@ -83,6 +87,7 @@ This setting is independent of the configured authentication method and will ove
 
 [source,yaml]
 ----
+clusterConfig:
   zookeeperConfigMapName: simple-nifi-znode
 ----
 NiFi in cluster mode requires a ZooKeeper ensemble for state management and leader election purposes, this operator at the moment does not support single node deployments without ZooKeeper, hence this is a required setting.
@@ -93,7 +98,6 @@ Configuration happens via a ConfigMap, which needs to contain two keys called `Z
 [source,yaml]
 ----
 config:
-  sensitivePropertyKeySecret: nifi-sensitive-property-key
   log:
     rootLogLevel: INFO
 ----

--- a/docs/modules/getting_started/examples/code/getting-started.sh
+++ b/docs/modules/getting_started/examples/code/getting-started.sh
@@ -113,8 +113,7 @@ spec:
   image:
     productVersion: 1.18.0
     stackableVersion: 0.3.0
-  zookeeperConfigMapName: simple-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
@@ -123,6 +122,7 @@ spec:
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
       autoGenerate: true
+    zookeeperConfigMapName: simple-nifi-znode
   nodes:
     roleGroups:
       default:

--- a/docs/modules/usage_guide/pages/security.adoc
+++ b/docs/modules/usage_guide/pages/security.adoc
@@ -24,7 +24,6 @@ stringData:
 [source,yaml]
 ----
 spec:
-  [...]
   clusterConfig:
     authentication:
       method:
@@ -50,7 +49,6 @@ kind: NifiCluster
 metadata:
   name: test-nifi
 spec:
-  [...]
   clusterConfig:
     authentication:
       method:

--- a/docs/modules/usage_guide/pages/security.adoc
+++ b/docs/modules/usage_guide/pages/security.adoc
@@ -25,7 +25,7 @@ stringData:
 ----
 spec:
   [...]
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
@@ -51,7 +51,7 @@ metadata:
   name: test-nifi
 spec:
   [...]
-  config:
+  clusterConfig:
     authentication:
       method:
         authenticationClass: ldap # <1>

--- a/docs/modules/usage_guide/pages/updating.adoc
+++ b/docs/modules/usage_guide/pages/updating.adoc
@@ -13,14 +13,14 @@ spec:
   image:
     productVersion: 1.16.3 # <1>
     stackableVersion: 0.3.0 # <2>
-  zookeeperConfigMapName: simple-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: simple-nifi-znode
   nodes:
     roleGroups:
       default:

--- a/examples/simple-nifi-cluster.yaml
+++ b/examples/simple-nifi-cluster.yaml
@@ -38,8 +38,7 @@ spec:
   image:
     productVersion: 1.18.0
     stackableVersion: 0.3.0
-  zookeeperConfigMapName: simple-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
@@ -48,6 +47,7 @@ spec:
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
       autoGenerate: true
+    zookeeperConfigMapName: simple-nifi-znode
   nodes:
     config:
       resources:
@@ -69,9 +69,6 @@ spec:
             capacity: "20Gi"
     roleGroups:
       default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
         config:
           log:
             rootLogLevel: INFO

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
                             .into_iter()
                             .filter(move |nifi: &Arc<NifiCluster>| {
                                 references_authentication_class(
-                                    &nifi.spec.config.authentication,
+                                    &nifi.spec.cluster_config.authentication,
                                     &authentication_class,
                                 )
                             })

--- a/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
@@ -32,8 +32,7 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: nifi-with-ldap-znode
-  config:
+  clusterConfig:
     authentication:
       method:
 {% if test_scenario['values']['ldap-use-tls'] == 'false' %}
@@ -43,6 +42,7 @@ spec:
 {% endif %}
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: nifi-with-ldap-znode
   nodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/orphaned_resources/01-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/01-install-nifi.yaml.j2
@@ -22,14 +22,14 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: test-nifi-znode
   nodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/resources/01-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/resources/01-install-nifi.yaml.j2
@@ -22,14 +22,14 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: test-nifi-znode
   nodes:
     config:
       resources:

--- a/tests/templates/kuttl/smoke/01-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/smoke/01-install-nifi.yaml.j2
@@ -22,14 +22,14 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: test-nifi-znode
   nodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/upgrade/01-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/01-install-nifi.yaml.j2
@@ -22,14 +22,14 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi_old'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi_old'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: test-nifi-znode
   nodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/upgrade/04-upgrade-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/04-upgrade-nifi.yaml.j2
@@ -7,14 +7,14 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['nifi_new'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['nifi_new'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-nifi-znode
-  config:
+  clusterConfig:
     authentication:
       method:
         singleUser:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
+    zookeeperConfigMapName: test-nifi-znode
   nodes:
     roleGroups:
       default:


### PR DESCRIPTION
# Description

- This is a pre PR for https://github.com/stackabletech/nifi-operator/issues/415
- renamed global `config` to `clusterConfig`
- moved `zookeeper_configmap_name` to `clusterConfig`
- adapted tests, docs and examples

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
