### PR TITLE
[Merged by Bors] - Fix vectorAggregatorConfigMapName in logging test

### DIFF
--- a/tests/templates/kuttl/logging/01-install-nifi-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-nifi-vector-aggregator.yaml
@@ -12,6 +12,6 @@ commands:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vector-aggregator-discovery
+  name: nifi-vector-aggregator-discovery
 data:
   ADDRESS: nifi-vector-aggregator:6123

--- a/tests/templates/kuttl/logging/03-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-nifi.yaml.j2
@@ -83,7 +83,7 @@ spec:
           adminCredentialsSecret: nifi-admin-credentials-simple
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
-    vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: nifi-vector-aggregator-discovery
     zookeeperConfigMapName: test-nifi-znode
   nodes:
     roleGroups:


### PR DESCRIPTION
# Description

Fix vectorAggregatorConfigMapName in logging test

The ConfigMap `vector-aggregator-discovery` in step `00-install-vector-aggregator-discovery-configmap` was overwritten in step `01-install-nifi-vector-aggregator`. The ZooKeeper logs were sent to the NiFi vector aggregator and not forwarded to the one specified by the environment variable `VECTOR_AGGREGATOR`.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
