### PR TITLE
[Merged by Bors] - Add documentation to explain how custom processors can be loaded into NiFi instances

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -20,7 +20,7 @@ FROM docker.stackable.tech/stackable/nifi:1.21.0-stackable0.0.0-dev
 COPY /path/to/your/nar.file /stackable/nifi/lib/
 ----
 
-You then need to make this image available to your Kubernetes cluster and specify it in your NiFi resource as described in xref:home:concepts:pages:product_image_selection.adoc[].
+You then need to make this image available to your Kubernetes cluster and specify it in your NiFi resource as described in xref:home:concepts:product_image_selection.adoc[].
 
 [source,yaml]
 ----

--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -6,6 +6,8 @@ For these to be available in the NiFi UI, they need to be present in the classpa
 
 The Stackable Data Platform supports two ways to achive this goal, both of which are described below.
 
+Please note that building your own Docker image is the recommended solution, as giving multiple pods access to a shared PVC can often be tricky (see comment on access mode in the second section).
+
 == Custom Docker Image
 
 You can extend the official Stackable NiFi image and simply copy all required nar files into the classpath of Nifi.
@@ -36,18 +38,17 @@ If you don't want to create a custom image, then you can use the extra volume mo
 For this to work you'll need to prepare a PVC containing your components.
 Usually the best way to do this will be to mount the PVC into a temporary container and then simply `kubectl cp` the nar files into that volume.
 
-The following listing shows an example of creating the PVC and the pod:
+The following listing shows an example of creating the PVC and the Pod:
 
 [source, yaml]
 ----
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: nifi-processor
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOnce  # <1>
   resources:
     requests:
       storage: 1Gi
@@ -73,6 +74,8 @@ spec:
           name: nifi-processor
 ----
 
+<1> Please note that this access mode will mean that you can only use this volume with a single NiFi pod. For a distributed scenario, a value of `ReadWriteMany` could be used if this is supported.
+
 The command to then copy the nar bundle into the PVC is:
 
 [source,bash]
@@ -87,7 +90,6 @@ After this is done your components will be available within the NiFi pods and Ni
 
 [source,yaml]
 ----
----
 apiVersion: nifi.stackable.tech/v1alpha1
 kind: NifiCluster
 metadata:

--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -74,7 +74,7 @@ spec:
           name: nifi-processor
 ----
 
-<1> Please note that this access mode will mean that you can only use this volume with a single NiFi pod. For a distributed scenario, a value of `ReadWriteMany` could be used if this is supported.
+<1> Please note that this access mode will mean that you can only use this volume with a single NiFi pod. For a distributed scenario, an additional list value of `ReadOnlyMany` could be specified here if this is supported.
 
 The command to then copy the nar bundle into the PVC is:
 

--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -1,0 +1,125 @@
+= Loading Custom Components
+
+It is possible to develop https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#introduction[custom components] for Apache NiFi to extend the available functionality - most often this will probably be custom processors.
+
+For these to be available in the NiFi UI, they need to be present in the classpath at startup, so the nar bundles have to be injected into your NiFi instance.
+
+The Stackable Data Platform supports two ways to achive this goal, both of which are described below.
+
+== Custom Docker Image
+
+You can extend the official Stackable NiFi image and simply copy all required nar files into the classpath of Nifi.
+The benefit of this method is that there is no need for any config overrides or extra mounts, you can simply use any ouf our NiFi examples, swap the image and your components will be available.
+But this means you will need to have access to a registry to push your custom image to.
+
+A simple Dockerfile would look like show in the following listing.
+
+[source,Dockerfile]
+----
+FROM docker.stackable.tech/stackable/nifi:1.21.0-stackable0.0.0-dev
+COPY /path/to/your/nar.file /stackable/nifi/lib/
+----
+
+You then need to make this image available to your Kubernetes cluster and specify it in your NiFi resource as described in xref:home:concepts:pages:product_image_selection.adoc[].
+
+[source,yaml]
+----
+spec:
+  image:
+    productVersion: 1.21.0
+    custom: "docker.company.org/nifi:1.21.0-customprocessor"
+----
+
+== Using the Official Image
+If you don't want to create a custom image, then you can use the extra volume mount functionality to load components and configure NiFi with to read these from the extra volumes.
+
+For this to work you'll need to prepare a PVC containing your components.
+Usually the best way to do this will be to mount the PVC into a temporary container and then simply `kubectl cp` the nar files into that volume.
+
+The following listing shows an example of creating the PVC and the pod:
+
+[source, yaml]
+----
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nifi-processor
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: processorcopy
+spec:
+  volumes:
+    - name: nifi-processor
+      persistentVolumeClaim:
+        claimName: nifi-processor
+  containers:
+    - name: copycontainer
+      image: alpine
+      command:
+        - tail
+        - "-f"
+        - "/dev/null"
+      volumeMounts:
+        - mountPath: "/volume"
+          name: nifi-processor
+----
+
+The command to then copy the nar bundle into the PVC is:
+
+[source,bash]
+----
+kubectl cp /path/to/component.nar processorcopy:/volume/
+----
+
+Now you can mount the extra volume into your NiFi instance as described in xref:nifi:usage_guide/extra-volumes.adoc[] .
+
+After this is done your components will be available within the NiFi pods and NiFi can be configured to load these at startup by adding an extra directory to the classpath:
+
+
+[source,yaml]
+----
+---
+apiVersion: nifi.stackable.tech/v1alpha1
+kind: NifiCluster
+metadata:
+  name: simple-nifi
+spec:
+  image:
+    productVersion: 1.21.0
+    stackableVersion: "0.0.0-dev"
+  clusterConfig:
+    extraVolumes: # <1>
+      - name: nifi-processor
+        persistentVolumeClaim:
+          claimName: nifi-processor
+    authentication:
+      method:
+        singleUser:
+          adminCredentialsSecret: nifi-admin-credentials-simple
+          autoGenerate: true
+    listenerClass: external-unstable
+    sensitiveProperties:
+      keySecret: nifi-sensitive-property-key
+      autoGenerate: true
+    zookeeperConfigMapName: simple-nifi-znode
+  nodes:
+    config:
+    configOverrides:
+      nifi.properties:
+        nifi.nar.library.directory.myCustomLibs: "../userdata/nifi-processor/" # <2>
+    roleGroups:
+      default:
+        replicas: 1
+----
+
+<1> Specify your prepared PVC here.
+<2> The directory name after `userdata` has to match the name of the volume, while `mycustomlibs` is a name you can freely change.

--- a/docs/modules/nifi/partials/nav.adoc
+++ b/docs/modules/nifi/partials/nav.adoc
@@ -6,6 +6,7 @@
 ** xref:nifi:usage_guide/pod-placement.adoc[]
 ** xref:nifi:usage_guide/zookeeper-connection.adoc[]
 ** xref:nifi:usage_guide/extra-volumes.adoc[]
+** xref:nifi:usage_guide/custom_processors.adoc[]
 ** xref:nifi:usage_guide/security.adoc[]
 ** xref:nifi:usage_guide/resource-configuration.adoc[]
 ** xref:nifi:usage_guide/log-aggregation.adoc[]


### PR DESCRIPTION
# Description
We had multiple requests about how custom components can be loaded into a Stackable managed NiFi instance.

This PR adds a page to the docs explaining two possible ways of achieving this goal:

- custom docker image
- extra volumes & config overrides

fixes #229 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
