### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -73,17 +73,31 @@ tests:
       - nifi-latest
       - zookeeper-latest
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: nifi
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: ldap-use-tls
+            expr: "true"
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
           - expr: last
       - dimensions:
           - name: openshift
+            expr: "true"
+          - name: nifi
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: ldap-use-tls
             expr: "true"


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62

```
(stackable) ➜  nifi-operator git:(feat/nightly-suite) ✗ beku -s nightly
INFO:root:Expanding test case id [upgrade_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi_old-1.18.0-stackable0.0.0-dev_nifi_new-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [orphaned_resources_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [smoke_zookeeper-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_listener-class-cluster-internal]
INFO:root:Expanding test case id [smoke_zookeeper-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_listener-class-external-unstable]
INFO:root:Expanding test case id [resources_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [ldap_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_ldap-use-tls-true_openshift-false]
INFO:root:Expanding test case id [logging_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster_operation_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-latest-1.21.0-stackable0.0.0-dev]
```
```
(stackable) ➜  nifi-operator git:(feat/nightly-suite) ✗ beku -s smoke-latest
INFO:root:Expanding test case id [smoke_zookeeper-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_listener-class-external-unstable]
```
```
(stackable) ➜  nifi-operator git:(feat/nightly-suite) ✗ beku -s openshift   
INFO:root:Expanding test case id [upgrade_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi_old-1.18.0-stackable0.0.0-dev_nifi_new-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [orphaned_resources_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [smoke_zookeeper-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_listener-class-external-unstable]
INFO:root:Expanding test case id [resources_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [ldap_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev_ldap-use-tls-true_openshift-true]
INFO:root:Expanding test case id [logging_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-1.21.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster_operation_zookeeper-latest-3.8.0-stackable0.0.0-dev_nifi-latest-1.21.0-stackable0.0.0-dev]
```

