### PR TITLE
Use keytool to rewrite truststore with AES encryption

### DIFF
--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -824,7 +824,7 @@ async fn build_node_rolegroup_statefulset(
         format!("echo Importing {KEYSTORE_NIFI_CONTAINER_MOUNT}/keystore.p12 to {STACKABLE_SERVER_TLS_DIR}/keystore.p12"),
         format!("cp {KEYSTORE_NIFI_CONTAINER_MOUNT}/keystore.p12 {STACKABLE_SERVER_TLS_DIR}/keystore.p12"),
         format!("echo Importing {KEYSTORE_NIFI_CONTAINER_MOUNT}/truststore.p12 to {STACKABLE_SERVER_TLS_DIR}/truststore.p12"),
-        format!("cp {KEYSTORE_NIFI_CONTAINER_MOUNT}/truststore.p12 {STACKABLE_SERVER_TLS_DIR}/truststore.p12"),
+        format!("keytool -importkeystore -srckeystore {KEYSTORE_NIFI_CONTAINER_MOUNT}/truststore.p12 -destkeystore {STACKABLE_SERVER_TLS_DIR}/truststore.p12 -srcstorepass {STACKABLE_TLS_STORE_PASSWORD} -deststorepass {STACKABLE_TLS_STORE_PASSWORD}"),
         "echo Replacing config directory".to_string(),
         "cp /conf/* /stackable/nifi/conf".to_string(),
         "ln -sf /stackable/log_config/logback.xml /stackable/nifi/conf/logback.xml".to_string(),


### PR DESCRIPTION
# Description

NiFi 1.18 fails to start, because it can't read the contents of the PKCS12 truststore. Since https://github.com/stackabletech/nifi-operator/pull/505, secret-operator handles the creation of the PKCS12 key- and truststore. To create the encrypted truststore, we use the [p12 crate](https://docs.rs/p12/latest/p12/), which creates the PKCS12 store using a legacy algorithm. Currently, we can't use the openssl crate for this, see [this comment](https://github.com/stackabletech/secret-operator/blob/2aee67ec4279ee733eae03c2ce6e7febe4572c30/rust/operator-binary/src/format/convert.rs#L89-L93).

As a workaround, until secret-operator is able to create the PKCS12 truststore with AES-256-CBC encryption (right now the p12 crate uses RC2-40-CBC), we import the truststore using keytool (which is able to read it) and export it again. Keytool encrypts the newly created truststore using AES-256-CBC.

This is the output when trying to open the truststore generated by secret-operator using openssl:
```
openssl pkcs12 -info -in truststore_sop.p12
Enter Import Password:
MAC: sha1, Iteration 2048
MAC length: 20, salt length: 8
PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
Error outputting keys and certificates
405520A8AA7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:373:Global default library con
text, Algorithm (RC2-40-CBC : 0), Properties ()
```

When we add the "-legacy" flag to openssl, it works:
```
openssl pkcs12 -info -in truststore_sop.p12 -legacy
Enter Import Password:
MAC: sha1, Iteration 2048
MAC length: 20, salt length: 8
PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
Certificate bag
Bag Attributes
    2.16.840.1.113894.746875.1.1: <No Values>
subject=CN = secret-operator self-signed
issuer=CN = secret-operator self-signed
-----BEGIN CERTIFICATE-----
MIIDVTCCAj2gAwIBAgIJAN8SbI7p4+tPMA0GCSqGSIb3DQEBCwUAMCYxJDAiBgNV
BAMMG3NlY3JldC1vcGVyYXRvciBzZWxmLXNpZ25lZDAeFw0yMzEwMDIwNzIxMDNa
...
```

Opening the "converted" truststore that is created by keytool:
```
openssl pkcs12 -info -in truststore.p12
Enter Import Password:
MAC: sha256, Iteration 10000
MAC length: 32, salt length: 20
PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC, Iteration 10000, PRF hmacWithSHA256
Certificate bag
Bag Attributes
    friendlyName: 1
    2.16.840.1.113894.746875.1.1: <Unsupported tag 6>
subject=CN = secret-operator self-signed
issuer=CN = secret-operator self-signed
-----BEGIN CERTIFICATE-----
MIIDVTCCAj2gAwIBAgIJAN8SbI7p4+tPMA0GCSqGSIb3DQEBCwUAMCYxJDAiBgNV
BAMMG3NlY3JldC1vcGVyYXRvciBzZWxmLXNpZ25lZDAeFw0yMzEwMDIwNzIxMDNa
...
```

We didn't investigate further why NiFi 1.20 and 1.21 don't seem to have problems with the legacy algorithm, while 1.18 does.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
