### PR TITLE
Make secretclass used for http tls configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Configuration overrides for the JVM security properties, such as DNS caching ([#497]).
 - Support PodDisruptionBudgets ([#509]).
 - Support for 1.23.2 ([#513]).
+- Support specifying the SecretClass that is used to obtain TLS certificates ([#529])
 
 ### Changed
 
@@ -31,6 +32,7 @@ All notable changes to this project will be documented in this file.
 [#505]: https://github.com/stackabletech/nifi-operator/pull/505
 [#509]: https://github.com/stackabletech/nifi-operator/pull/509
 [#513]: https://github.com/stackabletech/nifi-operator/pull/513
+[#529]: https://github.com/stackabletech/nifi-operator/pull/529
 
 ## [23.7.0] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Configuration overrides for the JVM security properties, such as DNS caching ([#497]).
 - Support PodDisruptionBudgets ([#509]).
 - Support for 1.23.2 ([#513]).
-- Support specifying the SecretClass that is used to obtain TLS certificates ([#529])
+- Support specifying the SecretClass that is used to obtain TLS certificates ([#529]).
 
 ### Changed
 
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - `operator-rs` `0.44.0` -> `0.55.0` ([#493], [#498], [#509], [#513]).
 - [BREAKING] Consolidated authentication config to a list of AuthenticationClasses ([#498]).
 - Let secret-operator handle certificate conversion ([#505]).
+- Secret volumes now only have the `Node` scope when a ListenerClass of `ExternalUnstable` is specified ([#529]).
 
 ### Removed
 

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -1151,6 +1151,16 @@ spec:
                       required:
                         - keySecret
                       type: object
+                    tls:
+                      default:
+                        httpSecretClass: tls
+                      nullable: true
+                      properties:
+                        httpSecretClass:
+                          default: tls
+                          description: 'The <https://docs.stackable.tech/secret-operator/stable/secretclass.html> to use for http communication. (mandatory). This setting controls: - Which cert the http servers should use to authenticate themselves towards users Defaults to `tls`'
+                          type: string
+                      type: object
                     vectorAggregatorConfigMapName:
                       description: Name of the Vector aggregator discovery ConfigMap. It must contain the key `ADDRESS` with the address of the Vector aggregator.
                       nullable: true

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -1,5 +1,26 @@
 = Security
 
+== Tls
+NiFi sets up Tls encryption for the http endpoints that serve the UI.
+By default, this interface is secured using certificates generated to work with the default SecretClass 'tls'.
+
+This can be configured to use a different SecretClass as shown below:
+
+[source, yaml]
+----
+apiVersion: nifi.stackable.tech/v1alpha1
+kind: NifiCluster
+metadata:
+  name: simple-nifi
+spec:
+  # Omitted for brevity
+  # ...
+  clusterConfig:
+    tls:
+      httpSecretClass: non-default-secret-class # <1>
+----
+<1> The name of the `SecretClass` that will be used for certificates for the NiFi UI.
+
 == Authentication
 
 Every user has to authenticate themselves before using NiFI.

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -104,8 +104,8 @@ pub struct NifiClusterConfig {
     /// Authentication options for NiFi (required)
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
-    #[serde(default = "tls::default_nifi_tls")]
-    pub tls: NifiTls,
+    #[serde(default = "tls::default_nifi_tls", skip_serializing_if = "Option::is_none")]
+    pub tls: Option<NifiTls>,
     /// Configuration options for how NiFi encrypts sensitive properties on disk
     pub sensitive_properties: NifiSensitivePropertiesConfig,
     /// Name of the Vector aggregator discovery ConfigMap.

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -106,7 +106,6 @@ pub struct NifiClusterConfig {
     pub authentication: Vec<NifiAuthenticationClassRef>,
     #[serde(
         default = "tls::default_nifi_tls",
-        skip_serializing_if = "Option::is_none"
     )]
     pub tls: Option<NifiTls>,
     /// Configuration options for how NiFi encrypts sensitive properties on disk

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -43,6 +43,7 @@ pub const BALANCE_PORT_NAME: &str = "balance";
 pub const BALANCE_PORT: u16 = 6243;
 pub const METRICS_PORT_NAME: &str = "metrics";
 pub const METRICS_PORT: u16 = 8081;
+pub const DEFAULT_SECRET_CLASS: &str = "tls";
 
 pub const STACKABLE_LOG_DIR: &str = "/stackable/log";
 pub const STACKABLE_LOG_CONFIG_DIR: &str = "/stackable/log_config";
@@ -102,6 +103,8 @@ pub struct NifiClusterConfig {
     /// Authentication options for NiFi (required)
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
+    #[serde(default = "default_secret_class")]
+    pub tls_secret_class: String,
     /// Configuration options for how NiFi encrypts sensitive properties on disk
     pub sensitive_properties: NifiSensitivePropertiesConfig,
     /// Name of the Vector aggregator discovery ConfigMap.
@@ -127,7 +130,9 @@ pub struct NifiClusterConfig {
     #[serde(default)]
     pub listener_class: CurrentlySupportedListenerClasses,
 }
-
+fn default_secret_class() -> String {
+    DEFAULT_SECRET_CLASS.to_string()
+}
 // TODO: Temporary solution until listener-operator is finished
 #[derive(Clone, Debug, Default, Display, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod affinity;
 pub mod authentication;
+mod tls;
 
 use crate::authentication::NifiAuthenticationClassRef;
 
+use crate::tls::NifiTls;
 use affinity::get_affinity;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -43,7 +45,6 @@ pub const BALANCE_PORT_NAME: &str = "balance";
 pub const BALANCE_PORT: u16 = 6243;
 pub const METRICS_PORT_NAME: &str = "metrics";
 pub const METRICS_PORT: u16 = 8081;
-pub const DEFAULT_SECRET_CLASS: &str = "tls";
 
 pub const STACKABLE_LOG_DIR: &str = "/stackable/log";
 pub const STACKABLE_LOG_CONFIG_DIR: &str = "/stackable/log_config";
@@ -103,8 +104,8 @@ pub struct NifiClusterConfig {
     /// Authentication options for NiFi (required)
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
-    #[serde(default = "default_secret_class")]
-    pub tls_secret_class: String,
+    #[serde(default = "tls::default_nifi_tls")]
+    pub tls: NifiTls,
     /// Configuration options for how NiFi encrypts sensitive properties on disk
     pub sensitive_properties: NifiSensitivePropertiesConfig,
     /// Name of the Vector aggregator discovery ConfigMap.
@@ -130,9 +131,7 @@ pub struct NifiClusterConfig {
     #[serde(default)]
     pub listener_class: CurrentlySupportedListenerClasses,
 }
-fn default_secret_class() -> String {
-    DEFAULT_SECRET_CLASS.to_string()
-}
+
 // TODO: Temporary solution until listener-operator is finished
 #[derive(Clone, Debug, Default, Display, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,11 +1,5 @@
-pub mod affinity;
-pub mod authentication;
-mod tls;
+use std::collections::BTreeMap;
 
-use crate::authentication::NifiAuthenticationClassRef;
-
-use crate::tls::NifiTls;
-use affinity::get_affinity;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
@@ -32,8 +26,16 @@ use stackable_operator::{
     schemars::{self, JsonSchema},
     status::condition::{ClusterCondition, HasStatusCondition},
 };
-use std::collections::BTreeMap;
 use strum::Display;
+
+use affinity::get_affinity;
+
+use crate::authentication::NifiAuthenticationClassRef;
+use crate::tls::NifiTls;
+
+pub mod affinity;
+pub mod authentication;
+mod tls;
 
 pub const APP_NAME: &str = "nifi";
 
@@ -104,9 +106,7 @@ pub struct NifiClusterConfig {
     /// Authentication options for NiFi (required)
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
-    #[serde(
-        default = "tls::default_nifi_tls",
-    )]
+    #[serde(default = "tls::default_nifi_tls")]
     pub tls: Option<NifiTls>,
     /// Configuration options for how NiFi encrypts sensitive properties on disk
     pub sensitive_properties: NifiSensitivePropertiesConfig,

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -15,11 +15,16 @@ pub struct NifiTls {
     pub http_secret_class: String,
 }
 
-/// Default TLS settings. Http communication default to "tls" secret class.
-pub fn default_nifi_tls() -> NifiTls {
-    NifiTls {
-        http_secret_class: http_tls_default(),
+impl Default for NifiTls {
+    fn default() -> Self {
+        NifiTls {
+            http_secret_class: http_tls_default(),
+        }
     }
+}
+/// Default TLS settings. Http communication default to "tls" secret class.
+pub fn default_nifi_tls() -> Option<NifiTls> {
+    Some(NifiTls::default())
 }
 
 /// Helper method to provide defaults in the CRDs and tests

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use stackable_operator::schemars::{self, JsonSchema};
+
+const TLS_DEFAULT_SECRET_CLASS: &str = "tls";
+
+#[derive(Clone, Deserialize, Debug, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NifiTls {
+    /// The <https://docs.stackable.tech/secret-operator/stable/secretclass.html> to use for
+    /// http communication.
+    /// (mandatory). This setting controls:
+    /// - Which cert the http servers should use to authenticate themselves towards users
+    /// Defaults to `tls`
+    #[serde(default = "http_tls_default")]
+    pub http_secret_class: String,
+}
+
+/// Default TLS settings. Http communication default to "tls" secret class.
+pub fn default_nifi_tls() -> NifiTls {
+    NifiTls {
+        http_secret_class: http_tls_default(),
+    }
+}
+
+/// Helper method to provide defaults in the CRDs and tests
+pub fn http_tls_default() -> String {
+    TLS_DEFAULT_SECRET_CLASS.into()
+}

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -70,8 +70,8 @@ use stackable_nifi_crd::{
 use crate::{
     authentication::{
         NifiAuthenticationConfig, AUTHORIZERS_XML_FILE_NAME,
-        LOGIN_IDENTITY_PROVIDERS_XML_FILE_NAME, STACKABLE_SERVER_TLS_DIR,
-        STACKABLE_TLS_STORE_PASSWORD,
+        LOGIN_IDENTITY_PROVIDERS_XML_FILE_NAME, STACKABLE_ADMIN_USER_NAME,
+        STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
     },
     config::{
         self, build_bootstrap_conf, build_nifi_properties, build_state_management_xml,

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1126,6 +1126,7 @@ async fn build_node_rolegroup_statefulset(
         )
         // One volume for the keystore and truststore data configmap
         .add_volume(build_keystore_volume(
+            &nifi.spec.cluster_config.tls_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi.name_any(),
             SecretFormat::TlsPkcs12,
@@ -1330,6 +1331,7 @@ fn build_reporting_task_job(
         )
         .add_container(cb.build())
         .add_volume(build_keystore_volume(
+            &nifi.spec.cluster_config.tls_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi_name,
             SecretFormat::TlsPem,
@@ -1422,11 +1424,12 @@ fn external_node_port(nifi_service: &Service) -> Result<i32> {
 }
 
 fn build_keystore_volume(
+    secret_class: &str,
     volume_name: &str,
     nifi_name: &str,
     secret_format: SecretFormat,
 ) -> Volume {
-    let mut secret_volume_source_builder = SecretOperatorVolumeSourceBuilder::new("tls");
+    let mut secret_volume_source_builder = SecretOperatorVolumeSourceBuilder::new(secret_class);
 
     if secret_format == SecretFormat::TlsPkcs12 {
         secret_volume_source_builder.with_tls_pkcs12_password(STACKABLE_TLS_STORE_PASSWORD);

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1540,3 +1540,24 @@ fn build_recommended_labels<'a>(
         role_group,
     }
 }
+
+
+#[cfg(test)]
+mod nifi_controller_test {
+    use stackable_operator::builder::SecretFormat;
+    use crate::controller::build_keystore_volume;
+    use crate::controller::Volume;
+
+    #[test]
+    pub fn test_build_keystore_volume() {
+        let volume: Volume = build_keystore_volume("tls_secret_class", "nifi-tls", "simple-nifi", SecretFormat::TlsPkcs12);
+
+        let annotations = volume.ephemeral.clone().unwrap().volume_claim_template.unwrap().metadata.unwrap().annotations.unwrap();
+        assert_eq!(annotations.get("secrets.stackable.tech/class"), Some(&"tls_secret_class".to_string()));
+        assert_eq!(annotations.get("secrets.stackable.tech/format"), Some(&"tls-pkcs12".to_string()));
+        assert_eq!(annotations.get("secrets.stackable.tech/scope"), Some(&"node,pod,service=simple-nifi".to_string()));
+
+        let spec = volume.ephemeral.unwrap().volume_claim_template.unwrap().spec;
+        assert_eq!(spec.storage_class_name, Some("secrets.stackable.tech".to_string()));
+    }
+}

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1126,7 +1126,7 @@ async fn build_node_rolegroup_statefulset(
         )
         // One volume for the keystore and truststore data configmap
         .add_volume(build_keystore_volume(
-            &nifi.spec.cluster_config.tls_secret_class,
+            &nifi.spec.cluster_config.tls.http_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi.name_any(),
             SecretFormat::TlsPkcs12,
@@ -1331,7 +1331,7 @@ fn build_reporting_task_job(
         )
         .add_container(cb.build())
         .add_volume(build_keystore_volume(
-            &nifi.spec.cluster_config.tls_secret_class,
+            &nifi.spec.cluster_config.tls.http_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi_name,
             SecretFormat::TlsPem,

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1,5 +1,4 @@
 //! Ensures that `Pod`s are configured and running for each [`NifiCluster`]
-use std::iter::Map;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
@@ -14,13 +13,6 @@ use product_config::{
 };
 use rand::{distributions::Alphanumeric, Rng};
 use snafu::{OptionExt, ResultExt, Snafu};
-use stackable_nifi_crd::{
-    authentication::resolve_authentication_classes, Container, CurrentlySupportedListenerClasses,
-    NifiCluster, NifiConfig, NifiConfigFragment, NifiRole, NifiStatus, APP_NAME, BALANCE_PORT,
-    BALANCE_PORT_NAME, HTTPS_PORT, HTTPS_PORT_NAME, MAX_NIFI_LOG_FILES_SIZE,
-    MAX_PREPARE_LOG_FILE_SIZE, METRICS_PORT, METRICS_PORT_NAME, PROTOCOL_PORT, PROTOCOL_PORT_NAME,
-    STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR,
-};
 use stackable_operator::{
     builder::{
         resources::ResourceRequirementsBuilder, ConfigMapBuilder, ContainerBuilder,
@@ -67,11 +59,19 @@ use stackable_operator::{
 use strum::{EnumDiscriminants, IntoStaticStr};
 use tracing::Instrument;
 
+use stackable_nifi_crd::{
+    authentication::resolve_authentication_classes, Container, CurrentlySupportedListenerClasses,
+    NifiCluster, NifiConfig, NifiConfigFragment, NifiRole, NifiStatus, APP_NAME, BALANCE_PORT,
+    BALANCE_PORT_NAME, HTTPS_PORT, HTTPS_PORT_NAME, MAX_NIFI_LOG_FILES_SIZE,
+    MAX_PREPARE_LOG_FILE_SIZE, METRICS_PORT, METRICS_PORT_NAME, PROTOCOL_PORT, PROTOCOL_PORT_NAME,
+    STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR,
+};
+
 use crate::{
     authentication::{
         NifiAuthenticationConfig, AUTHORIZERS_XML_FILE_NAME,
-        LOGIN_IDENTITY_PROVIDERS_XML_FILE_NAME, STACKABLE_ADMIN_USER_NAME,
-        STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
+        LOGIN_IDENTITY_PROVIDERS_XML_FILE_NAME, STACKABLE_SERVER_TLS_DIR,
+        STACKABLE_TLS_STORE_PASSWORD,
     },
     config::{
         self, build_bootstrap_conf, build_nifi_properties, build_state_management_xml,
@@ -1354,7 +1354,7 @@ fn build_reporting_task_job(
             SecretFormat::TlsPem,
             // Node scope only needed when exposed as nodeport aka ExternalUnstable
             nifi.spec.cluster_config.listener_class
-                == CurrentlySupportedListenerClasses::ExternalUnstable
+                == CurrentlySupportedListenerClasses::ExternalUnstable,
         ))
         .build_template();
 
@@ -1555,9 +1555,10 @@ fn build_recommended_labels<'a>(
 
 #[cfg(test)]
 mod nifi_controller_test {
+    use stackable_operator::builder::SecretFormat;
+
     use crate::controller::build_keystore_volume;
     use crate::controller::Volume;
-    use stackable_operator::builder::SecretFormat;
 
     #[test]
     pub fn test_build_keystore_volume_with_node_scope() {
@@ -1566,7 +1567,7 @@ mod nifi_controller_test {
             "nifi-tls",
             "simple-nifi",
             SecretFormat::TlsPkcs12,
-            true
+            true,
         );
 
         let annotations = volume
@@ -1611,7 +1612,7 @@ mod nifi_controller_test {
             "nifi-tls",
             "simple-nifi",
             SecretFormat::TlsPkcs12,
-            false
+            false,
         );
 
         let annotations = volume

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1126,7 +1126,13 @@ async fn build_node_rolegroup_statefulset(
         )
         // One volume for the keystore and truststore data configmap
         .add_volume(build_keystore_volume(
-            &nifi.spec.cluster_config.tls.http_secret_class,
+            &nifi
+                .spec
+                .cluster_config
+                .tls
+                .clone()
+                .unwrap_or_default()
+                .http_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi.name_any(),
             SecretFormat::TlsPkcs12,
@@ -1331,7 +1337,13 @@ fn build_reporting_task_job(
         )
         .add_container(cb.build())
         .add_volume(build_keystore_volume(
-            &nifi.spec.cluster_config.tls.http_secret_class,
+            &nifi
+                .spec
+                .cluster_config
+                .tls
+                .clone()
+                .unwrap_or_default()
+                .http_secret_class,
             KEYSTORE_VOLUME_NAME,
             &nifi_name,
             SecretFormat::TlsPem,


### PR DESCRIPTION
# Description
This PR adds configuration to specify the secret class that is used to generate certificates for securing the UI web interfaces.

It also omits specifying the "node" scope on secret operator volumes, unless `external_unstable` is specified as listener class. 

Until now both these things were hardcoded, secretclass was always 'tls' and volumes always requested the scopes 'node', 'pod' and 'service'. 

fixes #499


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
