### PR TITLE
fix(docs): make the getting started guide run reliably

### DIFF
--- a/docs/modules/nifi/examples/getting_started/getting_started.sh
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh
@@ -81,11 +81,11 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.8.3
+    productVersion: 3.9.2
   servers:
     roleGroups:
       default:
-        replicas: 3
+        replicas: 1
 EOF
 # end::install-zookeeper[]
 
@@ -155,7 +155,7 @@ spec:
   nodes:
     roleGroups:
       default:
-        replicas: 2
+        replicas: 1
 EOF
 # end::install-nifi[]
 
@@ -164,8 +164,6 @@ sleep 5
 echo "Awaiting NiFi rollout finish"
 # tag::wait-nifi-rollout[]
 kubectl wait -l statefulset.kubernetes.io/pod-name=simple-nifi-node-default-0 \
---for=condition=ready pod --timeout=1200s && \
-kubectl wait -l statefulset.kubernetes.io/pod-name=simple-nifi-node-default-1 \
 --for=condition=ready pod --timeout=1200s
 # end::wait-nifi-rollout[]
 

--- a/docs/modules/nifi/examples/getting_started/test-nifi.sh
+++ b/docs/modules/nifi/examples/getting_started/test-nifi.sh
@@ -23,7 +23,7 @@ nifi_jwt_token=$(curl -s -X POST --insecure --header 'content-type: application/
 
 x=1
 retry_interval_seconds=10
-expected_nodes=2
+expected_nodes=1
 
 while [ $x -le 15 ]
 do


### PR DESCRIPTION
# Description

* single pod for ZooKeeper (make the guide more lightweight)
* update ZooKeeper version to latest
* single pod for Nifi (fix random JWT validation failures and make the guide more lightweight)


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
