### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/cluster_operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/ldap/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/ldap/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/orphaned_resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/upgrade/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/upgrade/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -42,19 +42,23 @@ tests:
       - nifi_old
       - nifi_new
       - zookeeper-latest
+      - openshift
   - name: orphaned_resources
     dimensions:
       - nifi
       - zookeeper-latest
+      - openshift
   - name: smoke
     dimensions:
       - nifi
       - zookeeper
       - listener-class
+      - openshift
   - name: resources
     dimensions:
       - nifi
       - zookeeper-latest
+      - openshift
   - name: ldap
     dimensions:
       - nifi
@@ -65,10 +69,12 @@ tests:
     dimensions:
       - nifi
       - zookeeper-latest
+      - openshift
   - name: cluster_operation
     dimensions:
       - nifi-latest
       - zookeeper-latest
+      - openshift
 suites:
   - name: nightly
     patch:


### PR DESCRIPTION
# Description

Part of stackabletech/issues#566.

OKD:

```
--- PASS: kuttl (822.19s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/orphaned_resources_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-true (205.65s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.1_nifi-1.25.0_ldap-use-tls-true_openshift-true (241.52s)
        --- PASS: kuttl/harness/cluster_operation_zookeeper-latest-3.9.1_nifi-latest-1.25.0_openshift-true (208.70s)
        --- PASS: kuttl/harness/resources_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-true (155.54s)
        --- PASS: kuttl/harness/upgrade_zookeeper-latest-3.9.1_nifi_old-1.21.0_nifi_new-1.25.0_openshift-true (422.08s)
        --- PASS: kuttl/harness/logging_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-true (128.26s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.8.3_nifi-1.25.0_openshift-true_listener-class-external-unstable (243.72s)
```

Azure:

```
--- PASS: kuttl (1023.94s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/orphaned_resources_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-false (203.50s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.8.3_nifi-1.25.0_openshift-false_listener-class-cluster-internal (209.23s)
        --- PASS: kuttl/harness/resources_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-false (161.74s)
        --- PASS: kuttl/harness/logging_zookeeper-latest-3.9.1_nifi-1.25.0_openshift-false (120.58s)
        --- PASS: kuttl/harness/upgrade_zookeeper-latest-3.9.1_nifi_old-1.21.0_nifi_new-1.25.0_openshift-false (423.53s)
        --- PASS: kuttl/harness/cluster_operation_zookeeper-latest-3.9.1_nifi-latest-1.25.0_openshift-false (292.31s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.1_nifi-1.25.0_ldap-use-tls-true_openshift-false (250.38s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.8.3_nifi-1.25.0_openshift-false_listener-class-external-unstable (242.94s)
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
