### PR TITLE
feat: support custom images in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Make it easy to test custom Nifi images ([#616])
+
+[#616]: https://github.com/stackabletech/nifi-operator/pull/616
+
 ## [24.3.0] - 2024-03-20
 
 ### Added

--- a/tests/templates/kuttl/cluster_operation/20-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/20-install-nifi.yaml.j2
@@ -29,7 +29,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi-latest'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi-latest'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi-latest'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi-latest'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/cluster_operation/30-stop-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/30-stop-nifi.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi-latest'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi-latest'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi-latest'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi-latest'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/cluster_operation/40-pause-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/40-pause-nifi.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi-latest'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi-latest'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi-latest'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi-latest'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/cluster_operation/50-restart-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/50-restart-nifi.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi-latest'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi-latest'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi-latest'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi-latest'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
@@ -22,7 +22,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/logging/03-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-nifi.yaml.j2
@@ -83,7 +83,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/orphaned_resources/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/02-install-nifi.yaml.j2
@@ -29,7 +29,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/resources/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/resources/02-install-nifi.yaml.j2
@@ -29,7 +29,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
@@ -29,7 +29,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     zookeeperConfigMapName: test-nifi-znode

--- a/tests/templates/kuttl/upgrade/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/02-install-nifi.yaml.j2
@@ -29,7 +29,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi_old'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi_old'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi_old'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi_old'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/templates/kuttl/upgrade/05-assert.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-assert.yaml.j2
@@ -16,4 +16,9 @@ kind: NifiCluster
 metadata:
   name: test-nifi
 status:
+{% if test_scenario['values']['nifi_new'].find(",") > 0 %}
+  deployed_version: "{{ test_scenario['values']['nifi_new'].split(',')[0] }}"
+{% else %}
   deployed_version: {{ test_scenario['values']['nifi_new'].split("-")[0]  }}
+{% endif %}
+ 

--- a/tests/templates/kuttl/upgrade/05-upgrade-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-upgrade-nifi.yaml.j2
@@ -5,7 +5,12 @@ metadata:
   name: test-nifi
 spec:
   image:
+{% if test_scenario['values']['nifi_new'].find(",") > 0 %}
+    custom: "{{ test_scenario['values']['nifi_new'].split(',')[1] }}"
+    productVersion: "{{ test_scenario['values']['nifi_new'].split(',')[0] }}"
+{% else %}
     productVersion: "{{ test_scenario['values']['nifi_new'] }}"
+{% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
     authentication:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -12,18 +12,27 @@ dimensions:
       - 3.9.2
   - name: nifi
     values:
-      - 1.21.0
-      - 1.23.2
-      - 1.25.0
+      #- 1.21.0
+      #- 1.23.2
+      #- 1.25.0
+      # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
+      # as in the example below.
+      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: nifi_old
     values:
       - 1.21.0
   - name: nifi_new
     values:
-      - 1.25.0
+      #- 1.25.0
+      # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
+      # as in the example below.
+      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: nifi-latest
     values:
-      - 1.25.0
+      #- 1.25.0
+      # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
+      # as in the example below.
+      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: ldap-use-tls
     values:
       - "false"

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -12,27 +12,27 @@ dimensions:
       - 3.9.2
   - name: nifi
     values:
-      #- 1.21.0
-      #- 1.23.2
-      #- 1.25.0
+      - 1.21.0
+      - 1.23.2
+      - 1.25.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
+      # - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: nifi_old
     values:
       - 1.21.0
   - name: nifi_new
     values:
-      #- 1.25.0
+      - 1.25.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
+      # - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: nifi-latest
     values:
-      #- 1.25.0
+      - 1.25.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
+      # - 1.25.0,docker.stackable.tech/sandbox/nifi:1.25.0-stackable0.0.0-dev
   - name: ldap-use-tls
     values:
       - "false"


### PR DESCRIPTION
# Description

This was done to be able to test : https://github.com/stackabletech/docker-images/pull/663 as seen in the `test-definition.yaml` comments.

:warning:  CI: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/nifi-operator-it-custom/55/

:green_circle:  Fixing and rerunning the **failed** CI tests individually:
```
$ ./scripts/run-tests --skip-release --test-suite openshift --skip-delete --test upgrade
...
--- PASS: kuttl (405.61s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/upgrade_zookeeper-latest-3.9.2_nifi_old-1.21.0_nifi_new-1.25.0,docker.stackable.tech_sandbox_nifi_1.25.0-stackable0.0.0-dev_openshift-true (394.15s)
PASS
```

:green_circle: And

```
$ ./scripts/run-tests --skip-release --test-suite openshift --skip-delete --test cluster_operation
...
--- PASS: kuttl (346.00s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster_operation_zookeeper-latest-3.9.2_nifi-latest-1.25.0,docker.stackable.tech_sandbox_nifi_1.25.0-stackable0.0.0-dev_openshift-true (334.52s)
PASS
```
## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
