### PR TITLE
feat: Make https secretclass configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Support specifying the SecretClass that is used to obtain TLS certificates ([#XXX]).
+
 ### Changed
 
 - Make it easy to test custom Nifi images ([#616])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Support specifying the SecretClass that is used to obtain TLS certificates ([#XXX]).
+- Support specifying the SecretClass that is used to obtain TLS certificates ([#662]).
 
 ### Changed
 
 - Make it easy to test custom Nifi images ([#616])
 
 [#616]: https://github.com/stackabletech/nifi-operator/pull/616
+[#662]: https://github.com/stackabletech/nifi-operator/pull/662
 
 ## [24.3.0] - 2024-03-20
 

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -1212,7 +1212,7 @@ spec:
                       properties:
                         serverSecretClass:
                           default: tls
-                          description: 'Only affects client connections. This setting controls: - Which cert the servers should use to authenticate themselves against the client'
+                          description: This only affects client connections and is used to control which certificate the servers should use to authenticate themselves against the client.
                           type: string
                       type: object
                     vectorAggregatorConfigMapName:

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -1208,7 +1208,7 @@ spec:
                     tls:
                       default:
                         serverSecretClass: tls
-                      description: TLS configuration options for server.
+                      description: TLS configuration options for the server.
                       properties:
                         serverSecretClass:
                           default: tls

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -1205,6 +1205,16 @@ spec:
                       required:
                         - keySecret
                       type: object
+                    tls:
+                      default:
+                        serverSecretClass: tls
+                      description: TLS configuration options for server.
+                      properties:
+                        serverSecretClass:
+                          default: tls
+                          description: 'Only affects client connections. This setting controls: - Which cert the servers should use to authenticate themselves against the client'
+                          type: string
+                      type: object
                     vectorAggregatorConfigMapName:
                       description: Name of the Vector aggregator [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery). It must contain the key `ADDRESS` with the address of the Vector aggregator. Follow the [logging tutorial](https://docs.stackable.tech/home/nightly/tutorials/logging-vector-aggregator) to learn how to configure log aggregation with Vector.
                       nullable: true

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -1,5 +1,25 @@
 = Security
 
+== TLS
+
+NiFi sets up TLS encryption for the http endpoints that serve the UI.
+By default, this interface is secured using certificates generated to work with the default SecretClass `tls`.
+
+Nifi can be configured to use a different SecretClass as shown below:
+
+[source, yaml]
+----
+apiVersion: nifi.stackable.tech/v1alpha1
+kind: NifiCluster
+spec:
+  # ...
+  clusterConfig:
+    tls:
+      httpSecretClass: non-default-secret-class # <1>
+----
+
+<1> The name of the `SecretClass` that will be used for certificates for the NiFi UI.
+
 == Authentication
 
 Every user has to authenticate themselves before using NiFI.

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -15,7 +15,7 @@ spec:
   # ...
   clusterConfig:
     tls:
-      httpSecretClass: non-default-secret-class # <1>
+      serverSecretClass: non-default-secret-class # <1>
 ----
 
 <1> The name of the `SecretClass` that will be used for certificates for the NiFi UI.

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -116,7 +116,7 @@ pub struct NifiClusterConfig {
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
 
-    /// TLS configuration options for server.
+    /// TLS configuration options for the server.
     #[serde(default)]
     pub tls: NifiTls,
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod affinity;
 pub mod authentication;
+pub mod tls;
 
 use crate::authentication::NifiAuthenticationClassRef;
 
@@ -33,6 +34,7 @@ use stackable_operator::{
 };
 use std::collections::BTreeMap;
 use strum::Display;
+use tls::NifiTls;
 
 pub const APP_NAME: &str = "nifi";
 
@@ -113,6 +115,10 @@ pub struct NifiClusterConfig {
     /// Read more about authentication in the [security documentation](DOCS_BASE_URL_PLACEHOLDER/nifi/usage_guide/security).
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
+
+    /// TLS configuration options for server.
+    #[serde(default)]
+    pub tls: NifiTls,
 
     // no doc - docs in NifiSensitivePropertiesConfig struct.
     pub sensitive_properties: NifiSensitivePropertiesConfig,
@@ -479,6 +485,11 @@ impl NifiCluster {
         match role {
             NifiRole::Node => self.spec.nodes.as_ref().map(|n| &n.role_config),
         }
+    }
+
+    /// Return user provided server TLS settings
+    pub fn server_tls_secret_class(&self) -> &str {
+        &self.spec.cluster_config.tls.server_secret_class
     }
 
     /// List all pods expected to form the cluster

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -4,9 +4,9 @@ use stackable_operator::schemars::{self, JsonSchema};
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NifiTls {
-    /// Only affects client connections.
-    /// This setting controls:
-    /// - Which cert the servers should use to authenticate themselves against the client
+    /// This only affects client connections and is used to
+    /// control which certificate the servers should use to
+    /// authenticate themselves against the client.
     #[serde(default = "NifiTls::default_server_secret_class")]
     pub server_secret_class: String,
 }

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use stackable_operator::schemars::{self, JsonSchema};
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NifiTls {
+    /// Only affects client connections.
+    /// This setting controls:
+    /// - Which cert the servers should use to authenticate themselves against the client
+    #[serde(default = "NifiTls::default_server_secret_class")]
+    pub server_secret_class: String,
+}
+
+impl Default for NifiTls {
+    fn default() -> Self {
+        Self {
+            server_secret_class: Self::default_server_secret_class(),
+        }
+    }
+}
+
+impl NifiTls {
+    fn default_server_secret_class() -> String {
+        "tls".to_owned()
+    }
+}

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1208,6 +1208,7 @@ async fn build_node_rolegroup_statefulset(
         // One volume for the keystore and truststore data configmap
         .add_volume(
             build_tls_volume(
+                nifi,
                 KEYSTORE_VOLUME_NAME,
                 vec![
                     &nifi_cluster_name,

--- a/rust/operator-binary/src/reporting_task/mod.rs
+++ b/rust/operator-binary/src/reporting_task/mod.rs
@@ -321,6 +321,7 @@ fn build_reporting_task_job(
         .add_container(cb.build())
         .add_volume(
             build_tls_volume(
+                nifi,
                 REPORTING_TASK_CERT_VOLUME_NAME,
                 vec![],
                 SecretFormat::TlsPem,

--- a/rust/operator-binary/src/security/mod.rs
+++ b/rust/operator-binary/src/security/mod.rs
@@ -25,9 +25,10 @@ pub async fn check_or_generate_sensitive_key(client: &Client, nifi: &NifiCluster
 }
 
 pub fn build_tls_volume(
+    nifi: &NifiCluster,
     volume_name: &str,
     service_scopes: Vec<&str>,
     secret_format: SecretFormat,
 ) -> Result<Volume> {
-    tls::build_tls_volume(volume_name, service_scopes, secret_format).context(TlsSnafu)
+    tls::build_tls_volume(nifi, volume_name, service_scopes, secret_format).context(TlsSnafu)
 }

--- a/rust/operator-binary/src/security/tls.rs
+++ b/rust/operator-binary/src/security/tls.rs
@@ -1,4 +1,5 @@
 use snafu::{ResultExt, Snafu};
+use stackable_nifi_crd::NifiCluster;
 use stackable_operator::{
     builder::pod::volume::{SecretFormat, SecretOperatorVolumeSourceBuilder, VolumeBuilder},
     k8s_openapi::api::core::v1::Volume,
@@ -21,12 +22,13 @@ pub enum Error {
 }
 
 pub(crate) fn build_tls_volume(
+    nifi: &NifiCluster,
     volume_name: &str,
     service_scopes: Vec<&str>,
     secret_format: SecretFormat,
 ) -> Result<Volume> {
-    // TODO: Make adaptable (https://github.com/stackabletech/nifi-operator/issues/499)
-    let mut secret_volume_source_builder = SecretOperatorVolumeSourceBuilder::new("tls");
+    let mut secret_volume_source_builder =
+        SecretOperatorVolumeSourceBuilder::new(nifi.server_tls_secret_class());
 
     if secret_format == SecretFormat::TlsPkcs12 {
         secret_volume_source_builder.with_tls_pkcs12_password(STACKABLE_TLS_STORE_PASSWORD);


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/nifi-operator/issues/499

Alternate take on https://github.com/stackabletech/nifi-operator/pull/529, but a little bit more simplistic.
I also renamed `clusterConfig.tls.httpSecretClass` to `clusterConfig.tls.serverSecretClass` to be consistent with other operators (like zk or trino).

I skipped the whole "whether to request node certs" thing, as listener-op will replace it anyway.

## CRD change

```yaml
spec:
  clusterConfig:
    tls: # mandatory
      serverSecretClass: non-default-secret-class # mandatory, defaults to tls
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
