### PR TITLE
chore: Update LDAP bind OU, add quotes to DNs

### DIFF
--- a/rust/operator-binary/src/reporting_task/mod.rs
+++ b/rust/operator-binary/src/reporting_task/mod.rs
@@ -251,7 +251,7 @@ fn build_reporting_task_job(
         // In case of the username being simple (e.g admin for SingleUser) just use it as is
         format!("-u {STACKABLE_ADMIN_USER_NAME}")
     } else {
-        // If the username is a bind dn (e.g. cn=integrationtest,ou=users,dc=example,dc=org) we have to extract the cn/dn/uid (in this case integrationtest)
+        // If the username is a bind dn (e.g. cn=integrationtest,ou=my users,dc=example,dc=org) we have to extract the cn/dn/uid (in this case integrationtest)
         format!(
             "-u \"$(cat {admin_username_file} | grep -oP '((cn|dn|uid)=\\K[^,]+|.*)' | head -n 1)\""
         )

--- a/tests/templates/kuttl/ldap/create_ldap_user.sh
+++ b/tests/templates/kuttl/ldap/create_ldap_user.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
 # To check the existing users
-# ldapsearch -H ldap://localhost:1389 -D cn=admin,dc=example,dc=org -w admin -b ou=users,dc=example,dc=org
+# ldapsearch -H ldap://localhost:1389 -D "cn=admin,dc=example,dc=org" -w admin -b "ou=my users,dc=example,dc=org"
 
 # To check the new user
-# ldapsearch -H ldap://localhost:1389 -D cn=integrationtest,ou=users,dc=example,dc=org -w integrationtest -b ou=users,dc=example,dc=org
+# ldapsearch -H ldap://localhost:1389 -D "cn=integrationtest,ou=my users,dc=example,dc=org" -w integrationtest -b "ou=my users,dc=example,dc=org"
 
-cat << 'EOF' | ldapadd -H ldap://localhost:1389 -D cn=admin,dc=example,dc=org -w admin
+cat << 'EOF' | ldapadd -H ldap://localhost:1389 -D "cn=admin,dc=example,dc=org" -w admin
 dn: ou=my users,dc=example,dc=org
 ou: my users
 objectclass: top
 objectclass: organizationalUnit
 EOF
 
-cat << 'EOF' | ldapadd -H ldap://localhost:1389 -D cn=admin,dc=example,dc=org -w admin
+cat << 'EOF' | ldapadd -H ldap://localhost:1389 -D "cn=admin,dc=example,dc=org" -w admin
 dn: cn=integrationtest,ou=my users,dc=example,dc=org
 objectClass: inetOrgPerson
 objectClass: posixAccount
@@ -33,4 +33,4 @@ shadowMax: 0
 shadowWarning: 0
 EOF
 
-ldappasswd -H ldap://localhost:1389 -D cn=admin,dc=example,dc=org -w admin -s integrationtest "cn=integrationtest,ou=my users,dc=example,dc=org"
+ldappasswd -H ldap://localhost:1389 -D "cn=admin,dc=example,dc=org" -w admin -s integrationtest "cn=integrationtest,ou=my users,dc=example,dc=org"


### PR DESCRIPTION
# Description

The LDAP Bind DNs were changed, but not updated in the comments.
Since the new OU has a space, I have quoted all the DNs used in the commands.
