### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/log-aggregation.adoc
+++ b/docs/modules/nifi/pages/usage_guide/log-aggregation.adoc
@@ -15,4 +15,4 @@ spec:
 ----
 
 Further information on how to configure logging, can be found in
-xref:home:concepts:logging.adoc[].
+xref:concepts:logging.adoc[].

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed NiFi cluster is automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
+++ b/docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
@@ -31,7 +31,7 @@ In the above example, all nodes in the default group will request `12Gi` of stor
 
 == Resource Requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resource requests are configured explicitly, the NiFi operator uses the following defaults:
 

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -46,7 +46,7 @@ This setting is independent of the configured authentication method and will ove
 [#authentication-ldap]
 === LDAP
 
-NiFi supports xref:home:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:home:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
+NiFi supports xref:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
 The AuthenticationClass is then referenced in the NifiCluster resource as follows:
 
 [source,yaml]
@@ -64,7 +64,7 @@ spec:
 
 <1> The reference to an AuthenticationClass called `ldap`
 
-You can follow the xref:home:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
+You can follow the xref:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
 
 == Authorization
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)