### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
+++ b/docs/modules/nifi/pages/usage_guide/resource-configuration.adoc
@@ -32,7 +32,7 @@ In the above example, all nodes in the default group will request `12Gi` of stor
 
 == Resource requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 A minimal HA setup consisting of 2 NiFi instances has the following https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource requirements]:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)