### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed NiFi cluster is automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -40,7 +40,7 @@ Additional users can not be added.
 [#authentication-ldap]
 === LDAP
 
-NiFi supports xref:home:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:home:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
+NiFi supports xref:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
 The AuthenticationClass is then referenced in the NifiCluster resource as follows:
 
 [source,yaml]
@@ -59,7 +59,7 @@ spec:
 
 <1> The reference to an AuthenticationClass called `ldap`
 
-You can follow the xref:home:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
+You can follow the xref:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
 
 == Authorization
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)