### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637)

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -22,7 +22,7 @@ FROM docker.stackable.tech/stackable/nifi:1.23.2-stackable0.0.0-dev
 COPY /path/to/your/nar.file /stackable/nifi/lib/
 ----
 
-You then need to make this image available to your Kubernetes cluster and specify it in your NiFi resource as described in xref:home:concepts:product_image_selection.adoc[].
+You then need to make this image available to your Kubernetes cluster and specify it in your NiFi resource as described in xref:concepts:product_image_selection.adoc[].
 
 [source,yaml]
 ----

--- a/docs/modules/nifi/pages/usage_guide/log-aggregation.adoc
+++ b/docs/modules/nifi/pages/usage_guide/log-aggregation.adoc
@@ -15,4 +15,4 @@ spec:
 ----
 
 Further information on how to configure logging, can be found in
-xref:home:concepts:logging.adoc[].
+xref:concepts:logging.adoc[].

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed NiFi cluster is automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -55,7 +55,7 @@ spec:
 [#authentication-ldap]
 === LDAP
 
-NiFi supports xref:home:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:home:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
+NiFi supports xref:concepts:authentication.adoc[authentication] of users against an LDAP server. This requires setting up an xref:concepts:authentication.adoc#authenticationclass[AuthenticationClass] for the LDAP server.
 The AuthenticationClass is then referenced in the NifiCluster resource as follows:
 
 [source,yaml]
@@ -72,7 +72,7 @@ spec:
 
 <1> The reference to an AuthenticationClass called `ldap`
 
-You can follow the xref:home:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
+You can follow the xref:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the xref:reference:authenticationclass.adoc[] reference.
 
 == Authorization
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637)