### PR TITLE
feat: Allow configuring NiFi proxy host behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Allow configuring proxy host behaviour ([#668]).
+
 ### Changed
 
 - Reduce CRD size from `637KB` to `105KB` by accepting arbitrary YAML input instead of the underlying schema for the following fields ([#664]):
@@ -17,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 [#664]: https://github.com/stackabletech/nifi-operator/pull/664
 [#665]: https://github.com/stackabletech/nifi-operator/pull/665
+[#668]: https://github.com/stackabletech/nifi-operator/pull/668
 
 ## [24.7.0] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Allow configuring proxy host behaviour ([#668]).
+- Allow configuring proxy host behavior ([#668]).
 
 ### Changed
 

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -49,14 +49,17 @@ spec:
                       default:
                         additionalAllowedHosts: []
                         allowAll: true
+                      description: Configuration of allowed proxies e.g. load balancers or Kubernetes Ingress. Using a proxy that is not allowed by NiFi results in a failed host header check.
                       properties:
                         additionalAllowedHosts:
                           default: []
+                          description: List of proxy hosts to add to the default allow list deployed by SDP containing Kubernetes Services utilized by NiFi.
                           items:
                             type: string
                           type: array
                         allowAll:
                           default: true
+                          description: Allow all proxy hosts by turning off host header validation. See <https://github.com/stackabletech/docker-images/pull/694>
                           type: boolean
                       type: object
                     listenerClass:

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -45,6 +45,20 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       type: array
+                    hostHeaderCheck:
+                      default:
+                        additionalAllowedHosts: []
+                        allowAll: true
+                      properties:
+                        additionalAllowedHosts:
+                          default: []
+                          items:
+                            type: string
+                          type: array
+                        allowAll:
+                          default: true
+                          type: boolean
+                      type: object
                     listenerClass:
                       default: cluster-internal
                       description: |-

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -172,7 +172,7 @@ sensitiveProperties:
 == Host Header Check
 NiFi checks the Host header of incoming requests and rejects them if they are passing through a proxy that is not on an allow-list configured in the `nifi.web.proxy.host` property.
 
-A https://github.com/stackabletech/docker-images/pull/694[patch] applied during the build of the SDP container image for NiFi allows turning off this check by adding `nifi.web.proxy.host=*` to the properties. The Host header check for NiFi clusters created by the operator is turned off by default but can be turned in the NiFi configuration. In this case the list of allowed hosts will default to Kubernetes Services used by Nifi and can be extended with custom entries.
+A https://github.com/stackabletech/docker-images/pull/694[patch] applied during the build of the SDP container image for NiFi allows turning off this check by adding `nifi.web.proxy.host=*` to the properties. The Host header check for NiFi clusters created by the operator is disabled by default but can be enabled in the NiFi configuration. In this case the list of allowed hosts will default to Kubernetes Services used by NiFi and can be extended with custom entries.
 
 [source,yaml]
 ----

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -167,3 +167,19 @@ sensitiveProperties:
   keySecret: nifi-sensitive-property-key
   algorithm: nifiArgon2AesGcm256
 ----
+
+[#host-header-check]
+== Host Header Check
+NiFi checks the Host header of incoming requests and rejects them if they are passing through a proxy that is not on an allow-list configured in the `nifi.web.proxy.host` property.
+
+A https://github.com/stackabletech/docker-images/pull/694[patch] applied during the build of the SDP container image for NiFi allows turning off this check by adding `nifi.web.proxy.host=*` to the properties. The Host header check for NiFi clusters created by the operator is turned off by default but can be turned in the NiFi configuration. In this case the list of allowed hosts will default to Kubernetes Services used by Nifi and can be extended with custom entries.
+
+[source,yaml]
+----
+spec:
+  clusterConfig:
+    hostHeaderCheck:
+      allowAll: false
+      additionalAllowedHosts:
+      - example.com:1234
+----

--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -170,7 +170,7 @@ sensitiveProperties:
 
 [#host-header-check]
 == Host Header Check
-NiFi checks the Host header of incoming requests and rejects them if they are passing through a proxy that is not on an allow-list configured in the `nifi.web.proxy.host` property.
+NiFi checks the host header of incoming requests and rejects them if they are passing through a proxy that is not on an allow-list configured in the `nifi.web.proxy.host` property.
 
 A https://github.com/stackabletech/docker-images/pull/694[patch] applied during the build of the SDP container image for NiFi allows turning off this check by adding `nifi.web.proxy.host=*` to the properties. The Host header check for NiFi clusters created by the operator is disabled by default but can be enabled in the NiFi configuration. In this case the list of allowed hosts will default to Kubernetes Services used by NiFi and can be extended with custom entries.
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -171,25 +171,21 @@ pub struct HostHeaderCheckConfig {
     #[serde(default = "default_allow_all")]
     pub allow_all: bool,
     /// List of proxy hosts to add to the default allow list deployed by SDP containing Kubernetes Services utilized by NiFi.
-    #[serde(default = "default_additional_allowed_hosts")]
+    #[serde(default)]
     pub additional_allowed_hosts: Vec<String>,
 }
 
 impl Default for HostHeaderCheckConfig {
     fn default() -> Self {
         Self {
-            allow_all: true,
-            additional_allowed_hosts: vec![],
+            allow_all: default_allow_all(),
+            additional_allowed_hosts: Vec::default(),
         }
     }
 }
 
 pub fn default_allow_all() -> bool {
     true
-}
-
-pub fn default_additional_allowed_hosts() -> Vec<String> {
-    vec![]
 }
 
 // TODO: Temporary solution until listener-operator is finished

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -117,6 +117,11 @@ pub struct NifiClusterConfig {
     // We don't add `#[serde(default)]` here, as we require authentication
     pub authentication: Vec<NifiAuthenticationClassRef>,
 
+    /// Configuration of allowed proxies e.g. load balancers or Kubernetes Ingress. Using a proxy that is not allowed by NiFi results
+    /// in a failed host header check.
+    #[serde(default)]
+    pub host_header_check: HostHeaderCheckConfig,
+
     /// TLS configuration options for the server.
     #[serde(default)]
     pub tls: NifiTls,
@@ -156,6 +161,34 @@ pub struct NifiClusterConfig {
     /// will be used to expose the service, and ListenerClass names will stay the same, allowing for a non-breaking change.
     #[serde(default)]
     pub listener_class: CurrentlySupportedListenerClasses,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostHeaderCheckConfig {
+    /// Allow all proxy hosts by turning off host header validation.
+    #[serde(default = "default_allow_all")]
+    pub allow_all: bool,
+    /// List of proxy hosts to add to the default allow list deployed by SDP containing Kubernetes Services utilized by NiFi.
+    #[serde(default = "default_additional_allowed_hosts")]
+    pub additional_allowed_hosts: Vec<String>,
+}
+
+impl Default for HostHeaderCheckConfig {
+    fn default() -> Self {
+        Self {
+            allow_all: true,
+            additional_allowed_hosts: vec![],
+        }
+    }
+}
+
+pub fn default_allow_all() -> bool {
+    true
+}
+
+pub fn default_additional_allowed_hosts() -> Vec<String> {
+    vec![]
 }
 
 // TODO: Temporary solution until listener-operator is finished

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -167,6 +167,7 @@ pub struct NifiClusterConfig {
 #[serde(rename_all = "camelCase")]
 pub struct HostHeaderCheckConfig {
     /// Allow all proxy hosts by turning off host header validation.
+    /// See <https://github.com/stackabletech/docker-images/pull/694>
     #[serde(default = "default_allow_all")]
     pub allow_all: bool,
     /// List of proxy hosts to add to the default allow list deployed by SDP containing Kubernetes Services utilized by NiFi.

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1368,6 +1368,9 @@ async fn get_proxy_hosts(
 
     if host_header_check.allow_all {
         tracing::info!("spec.clusterConfig.hostHeaderCheck.allowAll is set to true. All proxy hosts will be allowed.");
+        if host_header_check.additional_allowed_hosts.len() > 0 {
+            tracing::info!("spec.clusterConfig.hostHeaderCheck.additionalAllowedHosts is ignored and only '*' is added to the allow-list.")
+        }
         return Ok("*".to_string());
     }
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1366,7 +1366,7 @@ async fn get_proxy_hosts(
 ) -> Result<String> {
     let host_header_check = nifi.spec.cluster_config.host_header_check.clone();
 
-    if host_header_check.allow_all == true {
+    if host_header_check.allow_all {
         tracing::info!("spec.clusterConfig.hostHeaderCheck.allowAll is set to true. Adding just \"*\" to allowed proxy hosts.");
         return Ok("*".to_string());
     }

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1367,7 +1367,7 @@ async fn get_proxy_hosts(
     let host_header_check = nifi.spec.cluster_config.host_header_check.clone();
 
     if host_header_check.allow_all {
-        tracing::info!("spec.clusterConfig.hostHeaderCheck.allowAll is set to true. Adding just \"*\" to allowed proxy hosts.");
+        tracing::info!("spec.clusterConfig.hostHeaderCheck.allowAll is set to true. All proxy hosts will be allowed.");
         return Ok("*".to_string());
     }
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1368,7 +1368,7 @@ async fn get_proxy_hosts(
 
     if host_header_check.allow_all {
         tracing::info!("spec.clusterConfig.hostHeaderCheck.allowAll is set to true. All proxy hosts will be allowed.");
-        if host_header_check.additional_allowed_hosts.len() > 0 {
+        if !host_header_check.additional_allowed_hosts.is_empty() {
             tracing::info!("spec.clusterConfig.hostHeaderCheck.additionalAllowedHosts is ignored and only '*' is added to the allow-list.")
         }
         return Ok("*".to_string());

--- a/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
@@ -42,6 +42,10 @@ spec:
     listenerClass: {{ test_scenario['values']['listener-class'] }}
     authentication:
       - authenticationClass: simple-nifi-users
+    hostHeaderCheck:
+      allowAll: false
+      additionalAllowedHosts:
+      - example.com:1234
     sensitiveProperties:
       keySecret: nifi-sensitive-property-key
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}

--- a/tests/templates/kuttl/smoke/31-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/31-assert.yaml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+commands:
+- script: kubectl get cm -n $NAMESPACE test-nifi-node-default -o yaml | grep -- 'nifi.web.proxy.host=.*example.com:1234' | xargs test ! -z


### PR DESCRIPTION
# Description

Allow adding proxy hosts that should be allowed by NiFi or turning the host header check off entirely.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
