### PR TITLE
fix: use flow.json.gz to easily migrate to version 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Switch from flow.xml.gz to flow.json.gz to allow seamless upgrades to version 2.0 ([#675]).
+- Switch from `flow.xml.gz` to `flow.json.gz` to allow seamless upgrades to version 2.0 ([#675]).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
   - `extraVolumes`
 - Increase `log` Volume size from 33 MiB to 500 MiB ([#671]).
 
+### Fixed
+
+- Switch from flow.xml.gz to flow.json.gz to allow seamless upgrades to version 2.0 ([#675]).
+
 ### Removed
 
 - Removed support for NiFi versions 1.21.0 and 1.25.0 ([#665]).
@@ -26,6 +30,7 @@ All notable changes to this project will be documented in this file.
 [#668]: https://github.com/stackabletech/nifi-operator/pull/668
 [#671]: https://github.com/stackabletech/nifi-operator/pull/671
 [#672]: https://github.com/stackabletech/nifi-operator/pull/672
+[#675]: https://github.com/stackabletech/nifi-operator/pull/675
 
 ## [24.7.0] - 2024-07-24
 

--- a/docs/modules/nifi/pages/usage_guide/updating.adoc
+++ b/docs/modules/nifi/pages/usage_guide/updating.adoc
@@ -1,7 +1,7 @@
 = Updating NiFi
 
 Updating (or downgrading for that matter) the deployed version of NiFi is as simple as changing the version stated in the CRD.
-Continuing the example above, to change the deployed version from `1.25.0` to `1.27.0` you'd simply deploy the following CRD.
+Continuing the example above, to change the deployed version from `1.27.0` to `2.0.0-M4` you'd simply deploy the following CRD.
 
 [source,yaml]
 ----
@@ -11,7 +11,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 1.27.0 # <1>
+    productVersion: 2.0.0-M4 # <1>
 ----
 
 <1> Change the NiFi version here
@@ -19,3 +19,7 @@ spec:
 WARNING: Due to a limitation in NiFi itself it is not possible to upgrade or downgrade a NiFi cluster in a rolling fashion.
 So any change to the NiFi version you make in this CRD will result in a full cluster restart with a short downtime.
 This does not affect the Stackable image version, this can be changed in a rolling fashion, as long as the underlying NiFi version remains unchanged.
+
+== NiFi 2.0.0-M4
+
+Before you can upgrade to `2.0.0-M4` you https://cwiki.apache.org/confluence/display/NIFI/Migration+Guidance[need to update] to at least version 1.27.x!

--- a/docs/modules/nifi/partials/supported-versions.adoc
+++ b/docs/modules/nifi/partials/supported-versions.adoc
@@ -4,3 +4,5 @@
 
 - 2.0.0-M4 (experimental) - Please note that you need to upgrade to at least 1.27.x before upgrading to 2.0.x!
 - 1.27.0 (LTS)
+
+For details on how to upgrade your NiFi version, please read on xref:usage_guide/updating.adoc[].

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -200,10 +200,14 @@ pub fn build_nifi_properties(
 ) -> Result<String, Error> {
     let mut properties = BTreeMap::new();
     // Core Properties
-    let flow_file_name = if product_version.starts_with("2") {
-        "flow.json.gz"
-    } else {
+    // According to https://cwiki.apache.org/confluence/display/NIFI/Migration+Guidance#MigrationGuidance-Migratingto2.0.0-M1
+    // The nifi.flow.configuration.file property in nifi.properties must be changed to reference
+    // "flow.json.gz" instead of "flow.xml.gz"
+    // TODO: Remove once we dropped support for all 1.x.x versions
+    let flow_file_name = if product_version.starts_with("1.") {
         "flow.xml.gz"
+    } else {
+        "flow.json.gz"
     };
     properties.insert(
         "nifi.flow.configuration.file".to_string(),

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -201,7 +201,7 @@ pub fn build_nifi_properties(
     // Core Properties
     properties.insert(
         "nifi.flow.configuration.file".to_string(),
-        NifiRepository::Database.mount_path() + "/flow.xml.gz",
+        NifiRepository::Database.mount_path() + "/flow.json.gz",
     );
     properties.insert(
         "nifi.flow.configuration.archive.enabled".to_string(),

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -196,12 +196,18 @@ pub fn build_nifi_properties(
     proxy_hosts: &str,
     auth_config: &NifiAuthenticationConfig,
     overrides: BTreeMap<String, String>,
+    product_version: &str,
 ) -> Result<String, Error> {
     let mut properties = BTreeMap::new();
     // Core Properties
+    let flow_file_name = if product_version.starts_with("2") {
+        "flow.json.gz"
+    } else {
+        "flow.xml.gz"
+    };
     properties.insert(
         "nifi.flow.configuration.file".to_string(),
-        NifiRepository::Database.mount_path() + "/flow.json.gz",
+        NifiRepository::Database.mount_path() + "/" + flow_file_name,
     );
     properties.insert(
         "nifi.flow.configuration.archive.enabled".to_string(),

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -764,6 +764,7 @@ async fn build_node_rolegroup_config_map(
                         kind: NIFI_PROPERTIES.to_string(),
                     })?
                     .clone(),
+                resolved_product_image.product_version.as_ref(),
             )
             .with_context(|_| BuildProductConfigSnafu {
                 rolegroup: rolegroup.clone(),

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -812,7 +812,7 @@ fn build_node_rolegroup_service(
     Ok(Service {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(nifi)
-            .name(&rolegroup.object_name())
+            .name(rolegroup.object_name())
             .ownerreference_from_resource(nifi, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(
@@ -991,24 +991,24 @@ async fn build_node_rolegroup_statefulset(
         .add_env_vars(env_vars.clone())
         .args(vec![prepare_args.join(" && ")])
         .add_volume_mount(
-            &NifiRepository::Flowfile.repository(),
-            &NifiRepository::Flowfile.mount_path(),
+            NifiRepository::Flowfile.repository(),
+            NifiRepository::Flowfile.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Database.repository(),
-            &NifiRepository::Database.mount_path(),
+            NifiRepository::Database.repository(),
+            NifiRepository::Database.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Content.repository(),
-            &NifiRepository::Content.mount_path(),
+            NifiRepository::Content.repository(),
+            NifiRepository::Content.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Provenance.repository(),
-            &NifiRepository::Provenance.mount_path(),
+            NifiRepository::Provenance.repository(),
+            NifiRepository::Provenance.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::State.repository(),
-            &NifiRepository::State.mount_path(),
+            NifiRepository::State.repository(),
+            NifiRepository::State.mount_path(),
         )
         .add_volume_mount("conf", "/conf")
         .add_volume_mount(KEYSTORE_VOLUME_NAME, KEYSTORE_NIFI_CONTAINER_MOUNT)
@@ -1058,24 +1058,24 @@ async fn build_node_rolegroup_statefulset(
         .add_env_vars(env_vars)
         .add_volume_mount(KEYSTORE_VOLUME_NAME, KEYSTORE_NIFI_CONTAINER_MOUNT)
         .add_volume_mount(
-            &NifiRepository::Flowfile.repository(),
-            &NifiRepository::Flowfile.mount_path(),
+            NifiRepository::Flowfile.repository(),
+            NifiRepository::Flowfile.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Database.repository(),
-            &NifiRepository::Database.mount_path(),
+            NifiRepository::Database.repository(),
+            NifiRepository::Database.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Content.repository(),
-            &NifiRepository::Content.mount_path(),
+            NifiRepository::Content.repository(),
+            NifiRepository::Content.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::Provenance.repository(),
-            &NifiRepository::Provenance.mount_path(),
+            NifiRepository::Provenance.repository(),
+            NifiRepository::Provenance.mount_path(),
         )
         .add_volume_mount(
-            &NifiRepository::State.repository(),
-            &NifiRepository::State.mount_path(),
+            NifiRepository::State.repository(),
+            NifiRepository::State.mount_path(),
         )
         .add_volume_mount("activeconf", NIFI_CONFIG_DIRECTORY)
         .add_volume_mount("log-config", STACKABLE_LOG_CONFIG_DIR)
@@ -1280,7 +1280,7 @@ async fn build_node_rolegroup_statefulset(
     Ok(StatefulSet {
         metadata: ObjectMetaBuilder::new()
             .name_and_namespace(nifi)
-            .name(&rolegroup_ref.object_name())
+            .name(rolegroup_ref.object_name())
             .ownerreference_from_resource(nifi, None, Some(true))
             .context(ObjectMissingMetadataForOwnerRefSnafu)?
             .with_recommended_labels(build_recommended_labels(

--- a/rust/operator-binary/src/security/sensitive_key.rs
+++ b/rust/operator-binary/src/security/sensitive_key.rs
@@ -61,7 +61,7 @@ pub(crate) async fn check_or_generate_sensitive_key(
             let new_secret = Secret {
                 metadata: ObjectMetaBuilder::new()
                     .namespace(namespace)
-                    .name(&sensitive_config.key_secret.to_string())
+                    .name(sensitive_config.key_secret.to_string())
                     .build(),
                 string_data: Some(secret_data),
                 ..Secret::default()

--- a/tests/templates/kuttl/upgrade/05-assert.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-assert.yaml.j2
@@ -19,5 +19,5 @@ status:
 {% if test_scenario['values']['nifi_new'].find(",") > 0 %}
   deployed_version: "{{ test_scenario['values']['nifi_new'].split(',')[0] }}"
 {% else %}
-  deployed_version: {{ test_scenario['values']['nifi_new'].split("-")[0]  }}
+  deployed_version: {{ test_scenario['values']['nifi_new'] }}
 {% endif %}

--- a/tests/templates/kuttl/upgrade/05-upgrade-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/05-upgrade-nifi.yaml.j2
@@ -11,21 +11,3 @@ spec:
 {% else %}
     productVersion: "{{ test_scenario['values']['nifi_new'] }}"
 {% endif %}
-    pullPolicy: IfNotPresent
-  clusterConfig:
-    authentication:
-      - authenticationClass: simple-nifi-users
-    sensitiveProperties:
-      keySecret: nifi-sensitive-property-key
-{% if lookup('env', 'VECTOR_AGGREGATOR') %}
-    vectorAggregatorConfigMapName: vector-aggregator-discovery
-{% endif %}
-    zookeeperConfigMapName: test-nifi-znode
-  nodes:
-    config:
-      logging:
-        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    roleGroups:
-      default:
-        config: {}
-        replicas: 3

--- a/tests/templates/kuttl/upgrade/generate-and-log-flowfiles.xml
+++ b/tests/templates/kuttl/upgrade/generate-and-log-flowfiles.xml
@@ -83,7 +83,7 @@
             <bundle>
                 <artifact>nifi-standard-nar</artifact>
                 <group>org.apache.nifi</group>
-                <version>1.21.0</version>
+                <version>1.27.0</version>
             </bundle>
             <config>
                 <backoffMechanism>PENALIZE_FLOWFILE</backoffMechanism>
@@ -222,7 +222,7 @@
             <bundle>
                 <artifact>nifi-standard-nar</artifact>
                 <group>org.apache.nifi</group>
-                <version>1.21.0</version>
+                <version>1.27.0</version>
             </bundle>
             <config>
                 <backoffMechanism>PENALIZE_FLOWFILE</backoffMechanism>

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -1,7 +1,3 @@
-# These tests can run against an OpenShift cluster, provided you note the following:
-#
-# 1. Set the "openshift" dimension below to "true" (with quotes)
-#
 ---
 dimensions:
   - name: zookeeper
@@ -19,16 +15,16 @@ dimensions:
       # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
   - name: nifi_old
     values:
-      - 1.25.0
+      - 1.27.0
   - name: nifi_new
     values:
-      - 1.27.0
+      - 2.0.0-M4
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
   - name: nifi-latest
     values:
-      - 1.27.0
+      - 2.0.0-M4
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
       # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev


### PR DESCRIPTION
# Description

part of: <https://github.com/stackabletech/docker-images/issues/836>

https://stackable-workspace.slack.com/archives/C031NP72H7T/p1726502134517489

> The older flow.xml.gz format was deprecated as of Apache NiFi 1.16 in favor of the newer flow.json.gz format.   NiFi 1.16+ will only load the flow.xml.gz if the flow.json.gz does not already exist during startup.  Upon successful startup, NiFi will generate the flow.json.gz.  The NiFi 1.16+ version will still generate both the flow.xml.gz and flow.json.gz formats with every change made on the UI. 
> With the major release of Apache NiFi 2.x, the deprecated flow.xml.gz format was removed.
There is no option in NiFi 2.0 to support the older flow.xml.gz format.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
