### PR TITLE
fix: make xref work from ROOT module

### DIFF
--- a/docs/modules/nifi/partials/supported-versions.adoc
+++ b/docs/modules/nifi/partials/supported-versions.adoc
@@ -5,4 +5,4 @@
 - 2.0.0-M4 (experimental) - Please note that you need to upgrade to at least 1.27.x before upgrading to 2.0.x!
 - 1.27.0 (LTS)
 
-For details on how to upgrade your NiFi version, please read on xref:usage_guide/updating.adoc[].
+For details on how to upgrade your NiFi version, please read on xref:nifi:usage_guide/updating.adoc[].


### PR DESCRIPTION
The docs build was broken because the `supported-versions.adoc` partial is included _outside_ the `nifi` module and then the xref didn't work anymore.

This is the fix.