### PR TITLE
fix: Disable create-reporting-task for NiFi 2.x and document regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
   - `extraVolumes`
 - Increase `log` Volume size from 33 MiB to 500 MiB ([#671]).
 - Replaced experimental NiFi `2.0.0-M4` with `2.0.0` ([#702]).
-- Remove the automatic deployment of the PrometheusReportingTask for NiFi versions `2.x.x` and up ([#708]).
+- Don't deploy the `PrometheusReportingTask` Job for NiFi versions `2.x.x` and up ([#708]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
   - `extraVolumes`
 - Increase `log` Volume size from 33 MiB to 500 MiB ([#671]).
 - Replaced experimental NiFi `2.0.0-M4` with `2.0.0` ([#702]).
+- Remove the automatic deployment of the PrometheusReportingTask for NiFi versions `2.x.x` and up ([#708]).
 
 ### Fixed
 
@@ -46,6 +47,7 @@ All notable changes to this project will be documented in this file.
 [#694]: https://github.com/stackabletech/nifi-operator/pull/694
 [#698]: https://github.com/stackabletech/nifi-operator/pull/698
 [#702]: https://github.com/stackabletech/nifi-operator/pull/702
+[#708]: https://github.com/stackabletech/nifi-operator/pull/708
 
 ## [24.7.0] - 2024-07-24
 

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -5,7 +5,8 @@
 
 In November 2024, Apache NiFi released a new major version https://cwiki.apache.org/confluence/display/NIFI/Release+Notes#ReleaseNotes-Version2.0.0[`2.0.0`].
 
-The NiFi `2.0.0` release changed the way of exposing Prometheus metrics significantly. The following steps explain on how to expose Metrics in NiFi versions `1.x.x` and `2.x.x`.
+The NiFi `2.0.0` release changed the way of exposing Prometheus metrics significantly.
+The following steps explain on how to expose Metrics in NiFi versions `1.x.x` and `2.x.x`.
 
 == Configure metrics in NiFi `1.x.x`
 
@@ -33,7 +34,8 @@ spec:
 
 == Configure metrics in NiFi `2.x.x`
 
-The Prometheus Reporting Task was removed in NiFi `2.x.x`. Metrics are now exposed automatically and can be scraped using the NiFi pod FQDN and the route `/nifi-api/flow/metrics/prometheus`.
+The Prometheus Reporting Task was removed in NiFi `2.x.x` in https://issues.apache.org/jira/browse/NIFI-13507[NIFI-13507].
+Metrics are now always exposed and can be scraped using the NiFi Pod FQDN and the HTTP path `/nifi-api/flow/metrics/prometheus`.
 
 For a deployed single node NiFi cluster called `simple-nifi`, containing a rolegroup called `default`, the metrics endpoint is reachable under:
 
@@ -41,4 +43,4 @@ For a deployed single node NiFi cluster called `simple-nifi`, containing a roleg
 https://simple-nifi-node-default-0.simple-nifi-node-default.<namespace>.svc.cluster.local:8443/nifi-api/flow/metrics/prometheus
 ```
 
-IMPORTANT: If NiFi is configured to use any Authentication, requests to the metric endpoint must be authenticated and authorized.
+IMPORTANT: If NiFi is configured to do any user authentication, requests to the metric endpoint must be authenticated and authorized.

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -3,10 +3,14 @@
 :k8s-job: https://kubernetes.io/docs/concepts/workloads/controllers/job/
 :k8s-network-policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 
-TODO: Update docs
+In November 2024, Apache NiFi released a new major version https://cwiki.apache.org/confluence/display/NIFI/Release+Notes#ReleaseNotes-Version2.0.0[`2.0.0`].
 
-The operator automatically configures NiFi to export Prometheus metrics.
-This is done by creating a {k8s-job}[Job] that connects to NiFi and configures a reporting task.
+The NiFi `2.0.0` release changed the way of exposing Prometheus metrics significantly. The following steps explain on how to expose Metrics in NiFi versions `1.x.x` and `2.x.x`.
+
+== Configure metrics in NiFi `1.x.x`
+
+For NiFi versions `1.x.x`, the operator automatically configures NiFi to export Prometheus metrics.
+This is done by creating a {k8s-job}[Job] that connects to NiFi and configures a https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-prometheus-nar/1.26.0/org.apache.nifi.reporting.prometheus.PrometheusReportingTask/index.html[Prometheus Reporting Task].
 
 IMPORTANT: Network access from the Job to NiFi is required.
 If you are running a Kubernetes with restrictive {k8s-network-policies}[NetworkPolicies], make sure to allow access from the Job to NiFi.
@@ -26,3 +30,24 @@ spec:
     createReportingTaskJob:
       enabled: false
 ----
+
+== Configure metrics in NiFi `2.x.x`
+
+The Prometheus Reporting Task was removed in NiFi `2.x.x`. Metrics now are exposed automatically and can be scraped using the NiFi pod FQDN and the route `/nifi-api/flow/metrics/prometheus`.
+This means automatic depoloyment of the ProtheusReportingTask should be disabled:
+
+[source,yaml]
+----
+spec:
+  clusterConfig:
+    createReportingTaskJob:
+      enabled: false
+----
+
+For a deployed single node NiFi cluster called `simple-nifi`, containing a rolegroup called `default`, the metrics endpoint is reachable under:
+
+```
+https://simple-nifi-node-default-0.simple-nifi-node-default.<namespace>.svc.cluster.local:8443/nifi-api/flow/metrics/prometheus
+```
+
+IMPORTANT: If NiFi is configured to use any Authentication, requests to the metric endpoint must be authenticated and authorized as well.

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -3,6 +3,8 @@
 :k8s-job: https://kubernetes.io/docs/concepts/workloads/controllers/job/
 :k8s-network-policies: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 
+TODO: Update docs
+
 The operator automatically configures NiFi to export Prometheus metrics.
 This is done by creating a {k8s-job}[Job] that connects to NiFi and configures a reporting task.
 

--- a/docs/modules/nifi/pages/usage_guide/monitoring.adoc
+++ b/docs/modules/nifi/pages/usage_guide/monitoring.adoc
@@ -33,16 +33,7 @@ spec:
 
 == Configure metrics in NiFi `2.x.x`
 
-The Prometheus Reporting Task was removed in NiFi `2.x.x`. Metrics now are exposed automatically and can be scraped using the NiFi pod FQDN and the route `/nifi-api/flow/metrics/prometheus`.
-This means automatic depoloyment of the ProtheusReportingTask should be disabled:
-
-[source,yaml]
-----
-spec:
-  clusterConfig:
-    createReportingTaskJob:
-      enabled: false
-----
+The Prometheus Reporting Task was removed in NiFi `2.x.x`. Metrics are now exposed automatically and can be scraped using the NiFi pod FQDN and the route `/nifi-api/flow/metrics/prometheus`.
 
 For a deployed single node NiFi cluster called `simple-nifi`, containing a rolegroup called `default`, the metrics endpoint is reachable under:
 
@@ -50,4 +41,4 @@ For a deployed single node NiFi cluster called `simple-nifi`, containing a roleg
 https://simple-nifi-node-default-0.simple-nifi-node-default.<namespace>.svc.cluster.local:8443/nifi-api/flow/metrics/prometheus
 ```
 
-IMPORTANT: If NiFi is configured to use any Authentication, requests to the metric endpoint must be authenticated and authorized as well.
+IMPORTANT: If NiFi is configured to use any Authentication, requests to the metric endpoint must be authenticated and authorized.

--- a/tests/templates/kuttl/smoke/60-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/60-assert.yaml.j2
@@ -4,4 +4,6 @@ kind: TestAssert
 timeout: 300
 commands:
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi.py -u admin -p 'passwordWithSpecialCharacter\@<&>"'"'" -n $NAMESPACE -c 3
+{% if test_scenario['values']['nifi'].startswith('1.') %}
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi_metrics.py -n $NAMESPACE
+{% endif %}

--- a/tests/templates/kuttl/upgrade/04-assert.yaml.j2
+++ b/tests/templates/kuttl/upgrade/04-assert.yaml.j2
@@ -4,5 +4,7 @@ kind: TestAssert
 timeout: 300
 commands:
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi.py -u admin -p supersecretpassword -n $NAMESPACE -c 3
+{% if test_scenario['values']['nifi_old'].startswith('1.') %}
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi_metrics.py -n $NAMESPACE
+{% endif %}
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- sh -c "python /tmp/flow.py -e https://test-nifi-node-default-0.test-nifi-node-default.$NAMESPACE.svc.cluster.local:8443 run -t /tmp/generate-and-log-flowfiles.xml > /tmp/old_input"

--- a/tests/templates/kuttl/upgrade/07-assert.yaml.j2
+++ b/tests/templates/kuttl/upgrade/07-assert.yaml.j2
@@ -6,7 +6,9 @@ metadata:
 timeout: 300
 commands:
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi.py -u admin -p supersecretpassword -n $NAMESPACE -c 3
+{% if test_scenario['values']['nifi_new'].startswith('1.') %}
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- python /tmp/test_nifi_metrics.py -n $NAMESPACE
+{% endif %}
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- sh -c "python /tmp/flow.py -e https://test-nifi-node-default-0.test-nifi-node-default.$NAMESPACE.svc.cluster.local:8443 query > /tmp/new_input"
   # This tests that the number of input records stays the same after the upgrade.
   - script: kubectl exec -n $NAMESPACE test-nifi-0 -- diff /tmp/old_input /tmp/new_input


### PR DESCRIPTION
# Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
