### PR TITLE
fix: Construction of OIDC endpoint when rootPath has no trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix OIDC endpoint calculation in case the `rootPath` does not have a trailing slash ([#718]).
+
+[#718]: https://github.com/stackabletech/nifi-operator/pull/718
+
 ## [24.11.0] - 2024-11-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix OIDC endpoint calculation in case the `rootPath` does not have a trailing slash ([#718]).
-
-[#718]: https://github.com/stackabletech/nifi-operator/pull/718
-
 ## [24.11.0] - 2024-11-18
 
 ### Added
@@ -36,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Switch from `flow.xml.gz` to `flow.json.gz` to allow seamless upgrades to version 2.0 ([#675]).
 - Failing to parse one `NifiCluster`/`AuthenticationClass` should no longer cause the whole operator to stop functioning ([#662]).
 - NiFi will now use the JDK trust store when an OIDC provider uses WebPKI as CA ([#686], [#698]).
+- Fix OIDC endpoint calculation in case the `rootPath` does not have a trailing slash ([#718]).
 
 ### Removed
 
@@ -56,6 +51,7 @@ All notable changes to this project will be documented in this file.
 [#698]: https://github.com/stackabletech/nifi-operator/pull/698
 [#702]: https://github.com/stackabletech/nifi-operator/pull/702
 [#708]: https://github.com/stackabletech/nifi-operator/pull/708
+[#718]: https://github.com/stackabletech/nifi-operator/pull/718
 
 ## [24.7.0] - 2024-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.
 - Switch from `flow.xml.gz` to `flow.json.gz` to allow seamless upgrades to version 2.0 ([#675]).
 - Failing to parse one `NifiCluster`/`AuthenticationClass` should no longer cause the whole operator to stop functioning ([#662]).
 - NiFi will now use the JDK trust store when an OIDC provider uses WebPKI as CA ([#686], [#698]).
-- Fix OIDC endpoint calculation in case the `rootPath` does not have a trailing slash ([#718]).
+- Fix OIDC endpoint construction in case the `rootPath` does not have a trailing slash ([#718]).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,10 +1784,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures 0.3.31",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.82",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustls"
@@ -2138,6 +2198,7 @@ dependencies = [
  "pin-project",
  "product-config",
  "rand",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -2152,8 +2213,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.80.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+version = "0.81.0"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
 dependencies = [
  "chrono",
  "clap",
@@ -2191,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2202,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#6fbe32300b60f95e0baa2ab0ff2daf961b06531c"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
 dependencies = [
  "kube",
  "semver",
@@ -2434,6 +2495,23 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2873,6 +2951,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.81.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
 dependencies = [
  "chrono",
  "clap",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#0daba5682732dc4997c9dc1a31362e576c031db7"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,8 +2213,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.81.0"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
+version = "0.82.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "chrono",
  "clap",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=fix/oidc-endpoint-calculation#4f93135f11b54bcb57fc39c6d79dba433a50918b"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#415bbd031bd52e9c0c5392060235030e9930b46b"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -2004,6 +2004,21 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "std" ];
       };
+      "futures-timer" = rec {
+        crateName = "futures-timer";
+        version = "3.0.3";
+        edition = "2018";
+        sha256 = "094vw8k37djpbwv74bwf2qb7n6v6ghif4myss6smd6hgyajb127j";
+        libName = "futures_timer";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "gloo-timers" = [ "dep:gloo-timers" ];
+          "send_wrapper" = [ "dep:send_wrapper" ];
+          "wasm-bindgen" = [ "gloo-timers" "send_wrapper" ];
+        };
+      };
       "futures-util" = rec {
         crateName = "futures-util";
         version = "0.3.31";
@@ -5031,6 +5046,23 @@ rec {
         };
         resolvedDefaultFeatures = [ "simd" "std" ];
       };
+      "proc-macro-crate" = rec {
+        crateName = "proc-macro-crate";
+        version = "3.2.0";
+        edition = "2021";
+        sha256 = "0yzsqnavb3lmrcsmbrdjfrky9vcbl46v59xi9avn0796rb3likwf";
+        libName = "proc_macro_crate";
+        authors = [
+          "Bastian Köcher <git@kchr.de>"
+        ];
+        dependencies = [
+          {
+            name = "toml_edit";
+            packageId = "toml_edit";
+          }
+        ];
+
+      };
       "proc-macro2" = rec {
         crateName = "proc-macro2";
         version = "1.0.89";
@@ -5424,6 +5456,20 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" "unicode" "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
       };
+      "relative-path" = rec {
+        crateName = "relative-path";
+        version = "1.9.3";
+        edition = "2021";
+        sha256 = "1limlh8fzwi21g0473fqzd6fln9iqkwvzp3816bxi31pkilz6fds";
+        libName = "relative_path";
+        authors = [
+          "John-John Tedro <udoprog@tedro.se>"
+        ];
+        features = {
+          "serde" = [ "dep:serde" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
       "ring" = rec {
         crateName = "ring";
         version = "0.17.8";
@@ -5489,6 +5535,105 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "default" "dev_urandom_fallback" ];
       };
+      "rstest" = rec {
+        crateName = "rstest";
+        version = "0.23.0";
+        edition = "2021";
+        sha256 = "0d90hr3i2yajzgpzvsh6p2yjzmcb3nm8884xdbb5sswvwmdmhb0a";
+        authors = [
+          "Michele d'Amico <michele.damico@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "futures";
+            packageId = "futures 0.3.31";
+            optional = true;
+          }
+          {
+            name = "futures-timer";
+            packageId = "futures-timer";
+            optional = true;
+          }
+          {
+            name = "rstest_macros";
+            packageId = "rstest_macros";
+            usesDefaultFeatures = false;
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "rustc_version";
+            packageId = "rustc_version";
+          }
+        ];
+        features = {
+          "async-timeout" = [ "dep:futures" "dep:futures-timer" "rstest_macros/async-timeout" ];
+          "crate-name" = [ "rstest_macros/crate-name" ];
+          "default" = [ "async-timeout" "crate-name" ];
+        };
+        resolvedDefaultFeatures = [ "async-timeout" "crate-name" "default" ];
+      };
+      "rstest_macros" = rec {
+        crateName = "rstest_macros";
+        version = "0.23.0";
+        edition = "2021";
+        sha256 = "0nmdm7a4ysihnh0zz6w6gqrmw205zfp7xqkb2id3858vg20afpl2";
+        procMacro = true;
+        authors = [
+          "Michele d'Amico <michele.damico@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "glob";
+            packageId = "glob";
+          }
+          {
+            name = "proc-macro-crate";
+            packageId = "proc-macro-crate";
+            optional = true;
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "regex";
+            packageId = "regex";
+          }
+          {
+            name = "relative-path";
+            packageId = "relative-path";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.82";
+            features = [ "full" "parsing" "extra-traits" "visit" "visit-mut" ];
+          }
+          {
+            name = "unicode-ident";
+            packageId = "unicode-ident";
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "rustc_version";
+            packageId = "rustc_version";
+          }
+        ];
+        features = {
+          "crate-name" = [ "dep:proc-macro-crate" ];
+          "default" = [ "async-timeout" "crate-name" ];
+        };
+        resolvedDefaultFeatures = [ "async-timeout" "crate-name" ];
+      };
       "rustc-demangle" = rec {
         crateName = "rustc-demangle";
         version = "0.1.24";
@@ -5503,6 +5648,19 @@ rec {
           "core" = [ "dep:core" ];
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
+      };
+      "rustc_version" = rec {
+        crateName = "rustc_version";
+        version = "0.4.1";
+        edition = "2018";
+        sha256 = "14lvdsmr5si5qbqzrajgb6vfn69k0sfygrvfvr2mps26xwi3mjyg";
+        dependencies = [
+          {
+            name = "semver";
+            packageId = "semver";
+          }
+        ];
+
       };
       "rustls" = rec {
         crateName = "rustls";
@@ -6671,17 +6829,23 @@ rec {
             features = [ "chrono" "git2" ];
           }
         ];
+        devDependencies = [
+          {
+            name = "rstest";
+            packageId = "rstest";
+          }
+        ];
 
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.80.0";
+        version = "0.81.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
+          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
         };
         libName = "stackable_operator";
         authors = [
@@ -6837,9 +7001,9 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
+          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -6872,9 +7036,9 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
+          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
         };
         libName = "stackable_shared";
         authors = [
@@ -7623,6 +7787,51 @@ rec {
           "tracing" = [ "dep:tracing" ];
         };
         resolvedDefaultFeatures = [ "codec" "default" "io" "slab" "time" ];
+      };
+      "toml_datetime" = rec {
+        crateName = "toml_datetime";
+        version = "0.6.8";
+        edition = "2021";
+        sha256 = "0hgv7v9g35d7y9r2afic58jvlwnf73vgd1mz2k8gihlgrf73bmqd";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "serde" = [ "dep:serde" ];
+        };
+      };
+      "toml_edit" = rec {
+        crateName = "toml_edit";
+        version = "0.22.22";
+        edition = "2021";
+        sha256 = "1xf7sxfzmnc45f75x302qrn5aph52vc8w226v59yhrm211i8vr2a";
+        authors = [
+          "Andronik Ordian <write@reusable.software>"
+          "Ed Page <eopage@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+            features = [ "std" ];
+          }
+          {
+            name = "toml_datetime";
+            packageId = "toml_datetime";
+          }
+          {
+            name = "winnow";
+            packageId = "winnow";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "parse" "display" ];
+          "parse" = [ "dep:winnow" ];
+          "perf" = [ "dep:kstring" ];
+          "serde" = [ "dep:serde" "toml_datetime/serde" "dep:serde_spanned" ];
+        };
+        resolvedDefaultFeatures = [ "default" "display" "parse" ];
       };
       "tower" = rec {
         crateName = "tower";
@@ -9424,6 +9633,28 @@ rec {
           "Microsoft"
         ];
 
+      };
+      "winnow" = rec {
+        crateName = "winnow";
+        version = "0.6.20";
+        edition = "2021";
+        sha256 = "16y4i8z9vh8hazjxg5mvmq0c5i35wlk8rxi5gkq6cn5vlb0zxh9n";
+        dependencies = [
+          {
+            name = "memchr";
+            packageId = "memchr";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "debug" = [ "std" "dep:anstream" "dep:anstyle" "dep:is-terminal" "dep:terminal_size" ];
+          "default" = [ "std" ];
+          "simd" = [ "dep:memchr" ];
+          "std" = [ "alloc" "memchr?/std" ];
+          "unstable-doc" = [ "alloc" "std" "simd" "unstable-recover" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
       };
       "xml-rs" = rec {
         crateName = "xml-rs";

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -2004,6 +2004,21 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "std" ];
       };
+      "futures-timer" = rec {
+        crateName = "futures-timer";
+        version = "3.0.3";
+        edition = "2018";
+        sha256 = "094vw8k37djpbwv74bwf2qb7n6v6ghif4myss6smd6hgyajb127j";
+        libName = "futures_timer";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "gloo-timers" = [ "dep:gloo-timers" ];
+          "send_wrapper" = [ "dep:send_wrapper" ];
+          "wasm-bindgen" = [ "gloo-timers" "send_wrapper" ];
+        };
+      };
       "futures-util" = rec {
         crateName = "futures-util";
         version = "0.3.31";
@@ -5031,6 +5046,23 @@ rec {
         };
         resolvedDefaultFeatures = [ "simd" "std" ];
       };
+      "proc-macro-crate" = rec {
+        crateName = "proc-macro-crate";
+        version = "3.2.0";
+        edition = "2021";
+        sha256 = "0yzsqnavb3lmrcsmbrdjfrky9vcbl46v59xi9avn0796rb3likwf";
+        libName = "proc_macro_crate";
+        authors = [
+          "Bastian Köcher <git@kchr.de>"
+        ];
+        dependencies = [
+          {
+            name = "toml_edit";
+            packageId = "toml_edit";
+          }
+        ];
+
+      };
       "proc-macro2" = rec {
         crateName = "proc-macro2";
         version = "1.0.89";
@@ -5424,6 +5456,20 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" "unicode" "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
       };
+      "relative-path" = rec {
+        crateName = "relative-path";
+        version = "1.9.3";
+        edition = "2021";
+        sha256 = "1limlh8fzwi21g0473fqzd6fln9iqkwvzp3816bxi31pkilz6fds";
+        libName = "relative_path";
+        authors = [
+          "John-John Tedro <udoprog@tedro.se>"
+        ];
+        features = {
+          "serde" = [ "dep:serde" ];
+        };
+        resolvedDefaultFeatures = [ "default" ];
+      };
       "ring" = rec {
         crateName = "ring";
         version = "0.17.8";
@@ -5489,6 +5535,105 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "default" "dev_urandom_fallback" ];
       };
+      "rstest" = rec {
+        crateName = "rstest";
+        version = "0.23.0";
+        edition = "2021";
+        sha256 = "0d90hr3i2yajzgpzvsh6p2yjzmcb3nm8884xdbb5sswvwmdmhb0a";
+        authors = [
+          "Michele d'Amico <michele.damico@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "futures";
+            packageId = "futures 0.3.31";
+            optional = true;
+          }
+          {
+            name = "futures-timer";
+            packageId = "futures-timer";
+            optional = true;
+          }
+          {
+            name = "rstest_macros";
+            packageId = "rstest_macros";
+            usesDefaultFeatures = false;
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "rustc_version";
+            packageId = "rustc_version";
+          }
+        ];
+        features = {
+          "async-timeout" = [ "dep:futures" "dep:futures-timer" "rstest_macros/async-timeout" ];
+          "crate-name" = [ "rstest_macros/crate-name" ];
+          "default" = [ "async-timeout" "crate-name" ];
+        };
+        resolvedDefaultFeatures = [ "async-timeout" "crate-name" "default" ];
+      };
+      "rstest_macros" = rec {
+        crateName = "rstest_macros";
+        version = "0.23.0";
+        edition = "2021";
+        sha256 = "0nmdm7a4ysihnh0zz6w6gqrmw205zfp7xqkb2id3858vg20afpl2";
+        procMacro = true;
+        authors = [
+          "Michele d'Amico <michele.damico@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "glob";
+            packageId = "glob";
+          }
+          {
+            name = "proc-macro-crate";
+            packageId = "proc-macro-crate";
+            optional = true;
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "regex";
+            packageId = "regex";
+          }
+          {
+            name = "relative-path";
+            packageId = "relative-path";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.82";
+            features = [ "full" "parsing" "extra-traits" "visit" "visit-mut" ];
+          }
+          {
+            name = "unicode-ident";
+            packageId = "unicode-ident";
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "rustc_version";
+            packageId = "rustc_version";
+          }
+        ];
+        features = {
+          "crate-name" = [ "dep:proc-macro-crate" ];
+          "default" = [ "async-timeout" "crate-name" ];
+        };
+        resolvedDefaultFeatures = [ "async-timeout" "crate-name" ];
+      };
       "rustc-demangle" = rec {
         crateName = "rustc-demangle";
         version = "0.1.24";
@@ -5503,6 +5648,19 @@ rec {
           "core" = [ "dep:core" ];
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
+      };
+      "rustc_version" = rec {
+        crateName = "rustc_version";
+        version = "0.4.1";
+        edition = "2018";
+        sha256 = "14lvdsmr5si5qbqzrajgb6vfn69k0sfygrvfvr2mps26xwi3mjyg";
+        dependencies = [
+          {
+            name = "semver";
+            packageId = "semver";
+          }
+        ];
+
       };
       "rustls" = rec {
         crateName = "rustls";
@@ -6671,17 +6829,23 @@ rec {
             features = [ "chrono" "git2" ];
           }
         ];
+        devDependencies = [
+          {
+            name = "rstest";
+            packageId = "rstest";
+          }
+        ];
 
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.80.0";
+        version = "0.82.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         libName = "stackable_operator";
         authors = [
@@ -6838,8 +7002,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -6873,8 +7037,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
-          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
+          rev = "415bbd031bd52e9c0c5392060235030e9930b46b";
+          sha256 = "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy";
         };
         libName = "stackable_shared";
         authors = [
@@ -7623,6 +7787,51 @@ rec {
           "tracing" = [ "dep:tracing" ];
         };
         resolvedDefaultFeatures = [ "codec" "default" "io" "slab" "time" ];
+      };
+      "toml_datetime" = rec {
+        crateName = "toml_datetime";
+        version = "0.6.8";
+        edition = "2021";
+        sha256 = "0hgv7v9g35d7y9r2afic58jvlwnf73vgd1mz2k8gihlgrf73bmqd";
+        authors = [
+          "Alex Crichton <alex@alexcrichton.com>"
+        ];
+        features = {
+          "serde" = [ "dep:serde" ];
+        };
+      };
+      "toml_edit" = rec {
+        crateName = "toml_edit";
+        version = "0.22.22";
+        edition = "2021";
+        sha256 = "1xf7sxfzmnc45f75x302qrn5aph52vc8w226v59yhrm211i8vr2a";
+        authors = [
+          "Andronik Ordian <write@reusable.software>"
+          "Ed Page <eopage@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "indexmap";
+            packageId = "indexmap";
+            features = [ "std" ];
+          }
+          {
+            name = "toml_datetime";
+            packageId = "toml_datetime";
+          }
+          {
+            name = "winnow";
+            packageId = "winnow";
+            optional = true;
+          }
+        ];
+        features = {
+          "default" = [ "parse" "display" ];
+          "parse" = [ "dep:winnow" ];
+          "perf" = [ "dep:kstring" ];
+          "serde" = [ "dep:serde" "toml_datetime/serde" "dep:serde_spanned" ];
+        };
+        resolvedDefaultFeatures = [ "default" "display" "parse" ];
       };
       "tower" = rec {
         crateName = "tower";
@@ -9424,6 +9633,28 @@ rec {
           "Microsoft"
         ];
 
+      };
+      "winnow" = rec {
+        crateName = "winnow";
+        version = "0.6.20";
+        edition = "2021";
+        sha256 = "16y4i8z9vh8hazjxg5mvmq0c5i35wlk8rxi5gkq6cn5vlb0zxh9n";
+        dependencies = [
+          {
+            name = "memchr";
+            packageId = "memchr";
+            optional = true;
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "debug" = [ "std" "dep:anstream" "dep:anstyle" "dep:is-terminal" "dep:terminal_size" ];
+          "default" = [ "std" ];
+          "simd" = [ "dep:memchr" ];
+          "std" = [ "alloc" "memchr?/std" ];
+          "unstable-doc" = [ "alloc" "std" "simd" "unstable-recover" ];
+        };
+        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
       };
       "xml-rs" = rec {
         crateName = "xml-rs";

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -2004,21 +2004,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "std" ];
       };
-      "futures-timer" = rec {
-        crateName = "futures-timer";
-        version = "3.0.3";
-        edition = "2018";
-        sha256 = "094vw8k37djpbwv74bwf2qb7n6v6ghif4myss6smd6hgyajb127j";
-        libName = "futures_timer";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
-        features = {
-          "gloo-timers" = [ "dep:gloo-timers" ];
-          "send_wrapper" = [ "dep:send_wrapper" ];
-          "wasm-bindgen" = [ "gloo-timers" "send_wrapper" ];
-        };
-      };
       "futures-util" = rec {
         crateName = "futures-util";
         version = "0.3.31";
@@ -5046,23 +5031,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "simd" "std" ];
       };
-      "proc-macro-crate" = rec {
-        crateName = "proc-macro-crate";
-        version = "3.2.0";
-        edition = "2021";
-        sha256 = "0yzsqnavb3lmrcsmbrdjfrky9vcbl46v59xi9avn0796rb3likwf";
-        libName = "proc_macro_crate";
-        authors = [
-          "Bastian Köcher <git@kchr.de>"
-        ];
-        dependencies = [
-          {
-            name = "toml_edit";
-            packageId = "toml_edit";
-          }
-        ];
-
-      };
       "proc-macro2" = rec {
         crateName = "proc-macro2";
         version = "1.0.89";
@@ -5456,20 +5424,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" "unicode" "unicode-age" "unicode-bool" "unicode-case" "unicode-gencat" "unicode-perl" "unicode-script" "unicode-segment" ];
       };
-      "relative-path" = rec {
-        crateName = "relative-path";
-        version = "1.9.3";
-        edition = "2021";
-        sha256 = "1limlh8fzwi21g0473fqzd6fln9iqkwvzp3816bxi31pkilz6fds";
-        libName = "relative_path";
-        authors = [
-          "John-John Tedro <udoprog@tedro.se>"
-        ];
-        features = {
-          "serde" = [ "dep:serde" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
       "ring" = rec {
         crateName = "ring";
         version = "0.17.8";
@@ -5535,105 +5489,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "default" "dev_urandom_fallback" ];
       };
-      "rstest" = rec {
-        crateName = "rstest";
-        version = "0.23.0";
-        edition = "2021";
-        sha256 = "0d90hr3i2yajzgpzvsh6p2yjzmcb3nm8884xdbb5sswvwmdmhb0a";
-        authors = [
-          "Michele d'Amico <michele.damico@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "futures";
-            packageId = "futures 0.3.31";
-            optional = true;
-          }
-          {
-            name = "futures-timer";
-            packageId = "futures-timer";
-            optional = true;
-          }
-          {
-            name = "rstest_macros";
-            packageId = "rstest_macros";
-            usesDefaultFeatures = false;
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "rustc_version";
-            packageId = "rustc_version";
-          }
-        ];
-        features = {
-          "async-timeout" = [ "dep:futures" "dep:futures-timer" "rstest_macros/async-timeout" ];
-          "crate-name" = [ "rstest_macros/crate-name" ];
-          "default" = [ "async-timeout" "crate-name" ];
-        };
-        resolvedDefaultFeatures = [ "async-timeout" "crate-name" "default" ];
-      };
-      "rstest_macros" = rec {
-        crateName = "rstest_macros";
-        version = "0.23.0";
-        edition = "2021";
-        sha256 = "0nmdm7a4ysihnh0zz6w6gqrmw205zfp7xqkb2id3858vg20afpl2";
-        procMacro = true;
-        authors = [
-          "Michele d'Amico <michele.damico@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "cfg-if";
-            packageId = "cfg-if";
-          }
-          {
-            name = "glob";
-            packageId = "glob";
-          }
-          {
-            name = "proc-macro-crate";
-            packageId = "proc-macro-crate";
-            optional = true;
-          }
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "regex";
-            packageId = "regex";
-          }
-          {
-            name = "relative-path";
-            packageId = "relative-path";
-          }
-          {
-            name = "syn";
-            packageId = "syn 2.0.82";
-            features = [ "full" "parsing" "extra-traits" "visit" "visit-mut" ];
-          }
-          {
-            name = "unicode-ident";
-            packageId = "unicode-ident";
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "rustc_version";
-            packageId = "rustc_version";
-          }
-        ];
-        features = {
-          "crate-name" = [ "dep:proc-macro-crate" ];
-          "default" = [ "async-timeout" "crate-name" ];
-        };
-        resolvedDefaultFeatures = [ "async-timeout" "crate-name" ];
-      };
       "rustc-demangle" = rec {
         crateName = "rustc-demangle";
         version = "0.1.24";
@@ -5648,19 +5503,6 @@ rec {
           "core" = [ "dep:core" ];
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
-      };
-      "rustc_version" = rec {
-        crateName = "rustc_version";
-        version = "0.4.1";
-        edition = "2018";
-        sha256 = "14lvdsmr5si5qbqzrajgb6vfn69k0sfygrvfvr2mps26xwi3mjyg";
-        dependencies = [
-          {
-            name = "semver";
-            packageId = "semver";
-          }
-        ];
-
       };
       "rustls" = rec {
         crateName = "rustls";
@@ -6829,23 +6671,17 @@ rec {
             features = [ "chrono" "git2" ];
           }
         ];
-        devDependencies = [
-          {
-            name = "rstest";
-            packageId = "rstest";
-          }
-        ];
 
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.81.0";
+        version = "0.80.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
-          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
+          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
         };
         libName = "stackable_operator";
         authors = [
@@ -7001,9 +6837,9 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
-          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
+          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -7036,9 +6872,9 @@ rec {
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "0daba5682732dc4997c9dc1a31362e576c031db7";
-          sha256 = "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "6fbe32300b60f95e0baa2ab0ff2daf961b06531c";
+          sha256 = "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3";
         };
         libName = "stackable_shared";
         authors = [
@@ -7787,51 +7623,6 @@ rec {
           "tracing" = [ "dep:tracing" ];
         };
         resolvedDefaultFeatures = [ "codec" "default" "io" "slab" "time" ];
-      };
-      "toml_datetime" = rec {
-        crateName = "toml_datetime";
-        version = "0.6.8";
-        edition = "2021";
-        sha256 = "0hgv7v9g35d7y9r2afic58jvlwnf73vgd1mz2k8gihlgrf73bmqd";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-        ];
-        features = {
-          "serde" = [ "dep:serde" ];
-        };
-      };
-      "toml_edit" = rec {
-        crateName = "toml_edit";
-        version = "0.22.22";
-        edition = "2021";
-        sha256 = "1xf7sxfzmnc45f75x302qrn5aph52vc8w226v59yhrm211i8vr2a";
-        authors = [
-          "Andronik Ordian <write@reusable.software>"
-          "Ed Page <eopage@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "indexmap";
-            packageId = "indexmap";
-            features = [ "std" ];
-          }
-          {
-            name = "toml_datetime";
-            packageId = "toml_datetime";
-          }
-          {
-            name = "winnow";
-            packageId = "winnow";
-            optional = true;
-          }
-        ];
-        features = {
-          "default" = [ "parse" "display" ];
-          "parse" = [ "dep:winnow" ];
-          "perf" = [ "dep:kstring" ];
-          "serde" = [ "dep:serde" "toml_datetime/serde" "dep:serde_spanned" ];
-        };
-        resolvedDefaultFeatures = [ "default" "display" "parse" ];
       };
       "tower" = rec {
         crateName = "tower";
@@ -9633,28 +9424,6 @@ rec {
           "Microsoft"
         ];
 
-      };
-      "winnow" = rec {
-        crateName = "winnow";
-        version = "0.6.20";
-        edition = "2021";
-        sha256 = "16y4i8z9vh8hazjxg5mvmq0c5i35wlk8rxi5gkq6cn5vlb0zxh9n";
-        dependencies = [
-          {
-            name = "memchr";
-            packageId = "memchr";
-            optional = true;
-            usesDefaultFeatures = false;
-          }
-        ];
-        features = {
-          "debug" = [ "std" "dep:anstream" "dep:anstyle" "dep:is-terminal" "dep:terminal_size" ];
-          "default" = [ "std" ];
-          "simd" = [ "dep:memchr" ];
-          "std" = [ "alloc" "memchr?/std" ];
-          "unstable-doc" = [ "alloc" "std" "simd" "unstable-recover" ];
-        };
-        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
       };
       "xml-rs" = rec {
         crateName = "xml-rs";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.80.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.82.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"
 url = { version = "2.5.2" }
 xml-rs = "0.8"
 
-[patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "fix/oidc-endpoint-calculation" }
+# [patch."https://github.com/stackabletech/operator-rs.git"]
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ xml-rs = "0.8"
 
 # [patch."https://github.com/stackabletech/operator-rs.git"]
 # stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+# stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ indoc = "2.0"
 pin-project = "1.1"
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 rand = "0.8"
+rstest = "0.23"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -31,5 +32,5 @@ tracing = "0.1"
 url = { version = "2.5.2" }
 xml-rs = "0.8"
 
-# [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "fix/oidc-endpoint-calculation" }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator-derive@0.3.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator@0.80.0": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-shared@0.0.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-operator-derive@0.3.1": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-operator@0.82.0": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.82.0#stackable-shared@0.0.1": "0phasjwb64rxgn5hs8vks92icmx9255bd5v9dms280clrfpcg4hy",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-operator-derive@0.3.1": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-operator@0.81.0": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-shared@0.0.1": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator-derive@0.3.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator@0.80.0": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-shared@0.0.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator-derive@0.3.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-operator@0.80.0": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.80.0#stackable-shared@0.0.1": "16jrq3wdwz63210jgmqbx3snrr15wxw6l1smqhzv7b7jpq8qvya3",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-operator-derive@0.3.1": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-operator@0.81.0": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=fix%2Foidc-endpoint-calculation#stackable-shared@0.0.1": "1p0fg8a5radj5xy2x02hlqm68hdsgpzwi9r5hfkfkxi2b6imb5js",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -29,5 +29,8 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true
+
 [build-dependencies]
 built.workspace = true

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -584,7 +584,9 @@ pub fn build_nifi_properties(
         "true".to_string(),
     );
 
-    add_oidc_config(auth_config, &mut properties).context(GenerateOidcConfigSnafu)?;
+    if let NifiAuthenticationConfig::Oidc { provider, oidc, .. } = auth_config {
+        add_oidc_config(provider, oidc, &mut properties).context(GenerateOidcConfigSnafu)?;
+    };
 
     // cluster node properties (only configure for cluster nodes)
     properties.insert("nifi.cluster.is.node".to_string(), "true".to_string());

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -10,11 +10,7 @@ use stackable_nifi_crd::{
     PROTOCOL_PORT,
 };
 use stackable_operator::{
-    commons::{
-        authentication::oidc::{AuthenticationProvider, DEFAULT_OIDC_WELLKNOWN_PATH},
-        resources::Resources,
-        tls_verification::{CaCert, TlsServerVerification, TlsVerification},
-    },
+    commons::resources::Resources,
     memory::{BinaryMultiple, MemoryQuantity},
     product_config_utils::{
         transform_all_roles_to_config, validate_all_roles_and_groups_config,
@@ -26,8 +22,11 @@ use strum::{Display, EnumIter};
 
 use crate::{
     operations::graceful_shutdown::graceful_shutdown_config_properties,
-    security::authentication::{
-        NifiAuthenticationConfig, STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
+    security::{
+        authentication::{
+            NifiAuthenticationConfig, STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
+        },
+        oidc::{self, add_oidc_config},
     },
 };
 
@@ -92,16 +91,8 @@ pub enum Error {
         repo: NifiRepository,
     },
 
-    #[snafu(display("invalid OIDC endpoint URL"))]
-    InvalidOidcEndpoint {
-        source: stackable_operator::commons::authentication::oidc::Error,
-    },
-
-    #[snafu(display("failed to build the OIDC wellkown path"))]
-    InvalidOidcWellknownPath { source: url::ParseError },
-
-    #[snafu(display("Nifi doesn't support skipping the OIDC TLS verification"))]
-    NoOidcTlsVerificationNotSupported {},
+    #[snafu(display("failed to generate OIDC config"))]
+    GenerateOidcConfig { source: oidc::Error },
 }
 
 /// Create the NiFi bootstrap.conf
@@ -593,55 +584,7 @@ pub fn build_nifi_properties(
         "true".to_string(),
     );
 
-    // OIDC config
-    if let NifiAuthenticationConfig::Oidc { provider, oidc, .. } = auth_config {
-        let endpoint_url = provider
-            .endpoint_url()
-            .context(InvalidOidcEndpointSnafu)?
-            .join(DEFAULT_OIDC_WELLKNOWN_PATH)
-            .context(InvalidOidcWellknownPathSnafu)?;
-        properties.insert(
-            "nifi.security.user.oidc.discovery.url".to_string(),
-            endpoint_url.to_string(),
-        );
-        let (oidc_client_id_env, oidc_client_secret_env) =
-            AuthenticationProvider::client_credentials_env_names(
-                &oidc.client_credentials_secret_ref,
-            );
-        properties.insert(
-            "nifi.security.user.oidc.client.id".to_string(),
-            format!("${{env:{oidc_client_id_env}}}").to_string(),
-        );
-        properties.insert(
-            "nifi.security.user.oidc.client.secret".to_string(),
-            format!("${{env:{oidc_client_secret_env}}}").to_string(),
-        );
-        let scopes = provider.scopes.join(",");
-        properties.insert(
-            "nifi.security.user.oidc.additional.scopes".to_string(),
-            scopes.to_string(),
-        );
-        properties.insert(
-            "nifi.security.user.oidc.claim.identifying.user".to_string(),
-            provider.principal_claim.to_string(),
-        );
-
-        if let Some(tls) = &provider.tls.tls {
-            let truststore_strategy = match tls.verification {
-                TlsVerification::None {} => NoOidcTlsVerificationNotSupportedSnafu.fail()?,
-                TlsVerification::Server(TlsServerVerification {
-                    ca_cert: CaCert::SecretClass(_),
-                }) => "NIFI", // The cert get's added to the stackable truststore
-                TlsVerification::Server(TlsServerVerification {
-                    ca_cert: CaCert::WebPki {},
-                }) => "JDK", // The cert needs to be in the system truststore
-            };
-            properties.insert(
-                "nifi.security.user.oidc.truststore.strategy".to_owned(),
-                truststore_strategy.to_owned(),
-            );
-        }
-    }
+    add_oidc_config(auth_config, &mut properties).context(GenerateOidcConfigSnafu)?;
 
     // cluster node properties (only configure for cluster nodes)
     properties.insert("nifi.cluster.is.node".to_string(), "true".to_string());

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -26,7 +26,7 @@ use crate::{
         authentication::{
             NifiAuthenticationConfig, STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
         },
-        oidc::{self, add_oidc_config},
+        oidc::{self, add_oidc_config_to_properties},
     },
 };
 
@@ -585,7 +585,8 @@ pub fn build_nifi_properties(
     );
 
     if let NifiAuthenticationConfig::Oidc { provider, oidc, .. } = auth_config {
-        add_oidc_config(provider, oidc, &mut properties).context(GenerateOidcConfigSnafu)?;
+        add_oidc_config_to_properties(provider, oidc, &mut properties)
+            .context(GenerateOidcConfigSnafu)?;
     };
 
     // cluster node properties (only configure for cluster nodes)

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -106,7 +106,8 @@ pub fn build_oidc_admin_password_secret_name(nifi: &NifiCluster) -> String {
     format!("{}-oidc-admin-password", nifi.name_any())
 }
 
-pub fn add_oidc_config(
+/// Adds all the needed configuration properties that are needed to enable OIDC authentication.
+pub fn add_oidc_config_to_properties(
     provider: &oidc::AuthenticationProvider,
     client_auth_options: &ClientAuthenticationOptions,
     properties: &mut BTreeMap<String, String>,
@@ -194,7 +195,8 @@ mod tests {
             product_specific_fields: (),
         };
 
-        add_oidc_config(&provider, &oidc, &mut properties).expect("OIDC config adding failed");
+        add_oidc_config_to_properties(&provider, &oidc, &mut properties)
+            .expect("OIDC config adding failed");
 
         assert_eq!(
             properties.get("nifi.security.user.oidc.additional.scopes"),

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -1,14 +1,20 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use rand::{distributions::Alphanumeric, Rng};
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_nifi_crd::NifiCluster;
 use stackable_operator::{
-    builder::meta::ObjectMetaBuilder, client::Client, k8s_openapi::api::core::v1::Secret,
-    kube::ResourceExt,
+    builder::meta::ObjectMetaBuilder,
+    client::Client,
+    commons::{
+        authentication::oidc::{AuthenticationProvider, DEFAULT_OIDC_WELLKNOWN_PATH},
+        tls_verification::{CaCert, TlsServerVerification, TlsVerification},
+    },
+    k8s_openapi::api::core::v1::Secret,
+    kube::{runtime::reflector::ObjectRef, ResourceExt},
 };
 
-use super::authentication::STACKABLE_ADMIN_USERNAME;
+use super::authentication::{NifiAuthenticationConfig, STACKABLE_ADMIN_USERNAME};
 
 const STACKABLE_OIDC_ADMIN_PASSWORD_KEY: &str = STACKABLE_ADMIN_USERNAME;
 
@@ -25,15 +31,24 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "found existing secret [{}/{}], but key {} is missing",
-        name,
-        namespace,
-        STACKABLE_OIDC_ADMIN_PASSWORD_KEY
+        "found existing admin password secret {secret:?}, but the key {STACKABLE_OIDC_ADMIN_PASSWORD_KEY} is missing",
     ))]
-    OidcAdminPasswordKeyMissing { name: String, namespace: String },
+    OidcAdminPasswordKeyMissing { secret: ObjectRef<Secret> },
+
+    #[snafu(display("invalid OIDC endpoint URL"))]
+    InvalidOidcEndpoint {
+        source: stackable_operator::commons::authentication::oidc::Error,
+    },
+
+    #[snafu(display("failed to build the OIDC wellknown path"))]
+    InvalidOidcWellknownPath { source: url::ParseError },
+
+    #[snafu(display("Nifi doesn't support skipping the OIDC TLS verification"))]
+    NoOidcTlsVerificationNotSupported {},
 }
 
-/// Generate a secret containing the password for the admin user that can access the API. This admin user is the same as for SingleUser authentication.
+/// Generate a secret containing the password for the admin user that can access the API. This admin
+/// user is the same as for SingleUser authentication.
 pub(crate) async fn check_or_generate_oidc_admin_password(
     client: &Client,
     nifi: &NifiCluster,
@@ -46,17 +61,17 @@ pub(crate) async fn check_or_generate_oidc_admin_password(
         .context(OidcAdminPasswordSecretSnafu)?
     {
         Some(secret) => {
-            let keys = secret
+            let admin_password_present = secret
                 .data
-                .unwrap_or_default()
-                .into_keys()
-                .collect::<HashSet<_>>();
-            if keys.contains(STACKABLE_OIDC_ADMIN_PASSWORD_KEY) {
+                .iter()
+                .flat_map(|data| data.keys())
+                .any(|key| key == STACKABLE_OIDC_ADMIN_PASSWORD_KEY);
+
+            if admin_password_present {
                 Ok(false)
             } else {
                 OidcAdminPasswordKeyMissingSnafu {
-                    name: build_oidc_admin_password_secret_name(nifi),
-                    namespace,
+                    secret: ObjectRef::from_obj(&secret),
                 }
                 .fail()?
             }
@@ -91,4 +106,60 @@ pub(crate) async fn check_or_generate_oidc_admin_password(
 
 pub fn build_oidc_admin_password_secret_name(nifi: &NifiCluster) -> String {
     format!("{}-oidc-admin-password", nifi.name_any())
+}
+
+pub fn add_oidc_config(
+    auth_config: &NifiAuthenticationConfig,
+    properties: &mut BTreeMap<String, String>,
+) -> Result<(), Error> {
+    let NifiAuthenticationConfig::Oidc { provider, oidc, .. } = auth_config else {
+        return Ok(());
+    };
+
+    let endpoint_url = provider
+        .endpoint_url()
+        .context(InvalidOidcEndpointSnafu)?
+        .join(DEFAULT_OIDC_WELLKNOWN_PATH)
+        .context(InvalidOidcWellknownPathSnafu)?;
+    properties.insert(
+        "nifi.security.user.oidc.discovery.url".to_string(),
+        endpoint_url.to_string(),
+    );
+    let (oidc_client_id_env, oidc_client_secret_env) =
+        AuthenticationProvider::client_credentials_env_names(&oidc.client_credentials_secret_ref);
+    properties.insert(
+        "nifi.security.user.oidc.client.id".to_string(),
+        format!("${{env:{oidc_client_id_env}}}").to_string(),
+    );
+    properties.insert(
+        "nifi.security.user.oidc.client.secret".to_string(),
+        format!("${{env:{oidc_client_secret_env}}}").to_string(),
+    );
+    let scopes = provider.scopes.join(",");
+    properties.insert(
+        "nifi.security.user.oidc.additional.scopes".to_string(),
+        scopes.to_string(),
+    );
+    properties.insert(
+        "nifi.security.user.oidc.claim.identifying.user".to_string(),
+        provider.principal_claim.to_string(),
+    );
+
+    if let Some(tls) = &provider.tls.tls {
+        let truststore_strategy = match tls.verification {
+            TlsVerification::None {} => NoOidcTlsVerificationNotSupportedSnafu.fail()?,
+            TlsVerification::Server(TlsServerVerification {
+                ca_cert: CaCert::SecretClass(_),
+            }) => "NIFI", // The cert get's added to the stackable truststore
+            TlsVerification::Server(TlsServerVerification {
+                ca_cert: CaCert::WebPki {},
+            }) => "JDK", // The cert needs to be in the system truststore
+        };
+        properties.insert(
+            "nifi.security.user.oidc.truststore.strategy".to_owned(),
+            truststore_strategy.to_owned(),
+        );
+    }
+
+    Ok(())
 }

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -106,7 +106,7 @@ pub fn build_oidc_admin_password_secret_name(nifi: &NifiCluster) -> String {
     format!("{}-oidc-admin-password", nifi.name_any())
 }
 
-/// Adds all the needed configuration properties that are needed to enable OIDC authentication.
+/// Adds all the required configuration properties to enable OIDC authentication.
 pub fn add_oidc_config_to_properties(
     provider: &oidc::AuthenticationProvider,
     client_auth_options: &ClientAuthenticationOptions,

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -68,7 +68,7 @@ pub(crate) async fn check_or_generate_oidc_admin_password(
             if admin_password_present {
                 Ok(false)
             } else {
-                OidcAdminPasswordKeyMissingSnafu {
+                MissingAdminPasswordKeySnafu {
                     secret: ObjectRef::from_obj(&secret),
                 }
                 .fail()?
@@ -113,14 +113,16 @@ pub fn add_oidc_config(
 ) -> Result<(), Error> {
     let well_known_url = provider
         .well_known_config_url()
-        .context(InvalidOidcWellKnownUrlSnafu)?;
+        .context(InvalidWellKnownConfigUrlSnafu)?;
 
     properties.insert(
         "nifi.security.user.oidc.discovery.url".to_string(),
         well_known_url.to_string(),
     );
     let (oidc_client_id_env, oidc_client_secret_env) =
-        AuthenticationProvider::client_credentials_env_names(&oidc.client_credentials_secret_ref);
+        AuthenticationProvider::client_credentials_env_names(
+            &client_auth_options.client_credentials_secret_ref,
+        );
     properties.insert(
         "nifi.security.user.oidc.client.id".to_string(),
         format!("${{env:{oidc_client_id_env}}}").to_string(),

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -40,9 +40,6 @@ pub enum Error {
         source: stackable_operator::commons::authentication::oidc::Error,
     },
 
-    #[snafu(display("failed to build the OIDC wellknown path"))]
-    InvalidOidcWellknownPath { source: url::ParseError },
-
     #[snafu(display("Nifi doesn't support skipping the OIDC TLS verification"))]
     NoOidcTlsVerificationNotSupported {},
 }

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -41,7 +41,7 @@ pub enum Error {
     },
 
     #[snafu(display("Nifi doesn't support skipping the OIDC TLS verification"))]
-    NoOidcTlsVerificationNotSupported {},
+    SkippingTlsVerificationNotSupported {},
 }
 
 /// Generate a secret containing the password for the admin user that can access the API.
@@ -144,7 +144,7 @@ pub fn add_oidc_config_to_properties(
 
     if let Some(tls) = &provider.tls.tls {
         let truststore_strategy = match tls.verification {
-            TlsVerification::None {} => NoOidcTlsVerificationNotSupportedSnafu.fail()?,
+            TlsVerification::None {} => SkippingTlsVerificationNotSupportedSnafu.fail()?,
             TlsVerification::Server(TlsServerVerification {
                 ca_cert: CaCert::SecretClass(_),
             }) => "NIFI", // The cert get's added to the stackable truststore

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -33,10 +33,10 @@ pub enum Error {
     #[snafu(display(
         "found existing admin password secret {secret:?}, but the key {STACKABLE_OIDC_ADMIN_PASSWORD_KEY} is missing",
     ))]
-    OidcAdminPasswordKeyMissing { secret: ObjectRef<Secret> },
+    MissingAdminPasswordKey { secret: ObjectRef<Secret> },
 
-    #[snafu(display("invalid OIDC well known URL"))]
-    InvalidOidcWellKnownUrl {
+    #[snafu(display("invalid well-known OIDC configuration URL"))]
+    InvalidWellKnownConfigUrl {
         source: stackable_operator::commons::authentication::oidc::Error,
     },
 
@@ -44,8 +44,9 @@ pub enum Error {
     NoOidcTlsVerificationNotSupported {},
 }
 
-/// Generate a secret containing the password for the admin user that can access the API. This admin
-/// user is the same as for SingleUser authentication.
+/// Generate a secret containing the password for the admin user that can access the API.
+///
+/// This admin user is the same as for SingleUser authentication.
 pub(crate) async fn check_or_generate_oidc_admin_password(
     client: &Client,
     nifi: &NifiCluster,
@@ -107,7 +108,7 @@ pub fn build_oidc_admin_password_secret_name(nifi: &NifiCluster) -> String {
 
 pub fn add_oidc_config(
     provider: &oidc::AuthenticationProvider,
-    oidc: &ClientAuthenticationOptions,
+    client_auth_options: &ClientAuthenticationOptions,
     properties: &mut BTreeMap<String, String>,
 ) -> Result<(), Error> {
     let well_known_url = provider

--- a/rust/operator-binary/src/security/oidc.rs
+++ b/rust/operator-binary/src/security/oidc.rs
@@ -114,7 +114,7 @@ pub fn add_oidc_config(
     properties: &mut BTreeMap<String, String>,
 ) -> Result<(), Error> {
     let well_known_url = provider
-        .well_known_url()
+        .well_known_config_url()
         .context(InvalidOidcWellKnownUrlSnafu)?;
 
     properties.insert(


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/nifi-operator/issues/716

Deploying nifi into the e2e-sec demo:

### With `rootPath: /realms/demo`
0.0.0-dev: `https://85.215.194.243:30584/realms/.well-known/openid-configuration` (obviously broken) => Caused by: org.springframework.web.client.HttpClientErrorException$NotFound: 404 Not Found: "{"error":"Realm does not exist"}"
This PR: `https://85.215.194.243:30584/realms/demo/.well-known/openid-configuration` => Correct :heavy_check_mark: 

### With `rootPath: /realms/demo/`

0.0.0-dev: `https://85.215.194.243:30584/realms/demo/.well-known/openid-configuration` => Correct :heavy_check_mark: 
This PR: `https://85.215.194.243:30584/realms/demo/.well-known/openid-configuration` => Correct :heavy_check_mark: 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
