### PR TITLE
chore: add oci references, merge templating changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ All notable changes to this project will be documented in this file.
 - Support configuring JVM arguments ([#724]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#742]).
 
+### Changed
+
+- Default to OCI for image metadata and product image selection ([#741]).
+
 [#722]: https://github.com/stackabletech/nifi-operator/pull/722
 [#724]: https://github.com/stackabletech/nifi-operator/pull/724
 [#730]: https://github.com/stackabletech/nifi-operator/pull/730
+[#741]: https://github.com/stackabletech/nifi-operator/pull/741
 [#742]: https://github.com/stackabletech/nifi-operator/pull/742
 
 ## [24.11.1] - 2025-01-10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,8 +2374,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.84.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+version = "0.85.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "chrono",
  "clap",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7389,18 +7389,22 @@ rec {
             name = "rstest";
             packageId = "rstest";
           }
+          {
+            name = "serde_yaml";
+            packageId = "serde_yaml";
+          }
         ];
 
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.84.1";
+        version = "0.85.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_operator";
         authors = [
@@ -7559,8 +7563,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -7594,8 +7598,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_shared";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.84.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.85.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator-derive@0.3.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator@0.84.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-shared@0.0.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator-derive@0.3.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator@0.85.0": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-shared@0.0.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/deploy/helm/nifi-operator/crds/crds.yaml
+++ b/deploy/helm/nifi-operator/crds/crds.yaml
@@ -193,7 +193,7 @@ spec:
                     Consult the [Product image selection documentation](https://docs.stackable.tech/home/nightly/concepts/product_image_selection) for details.
                   properties:
                     custom:
-                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `oci.stackable.tech/sdp/superset:1.4.1-stackable2.1.0`
                       type: string
                     productVersion:
                       description: Version of the product, e.g. `1.4.1`.
@@ -220,7 +220,7 @@ spec:
                       nullable: true
                       type: array
                     repo:
-                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      description: Name of the docker repo, e.g. `oci.stackable.tech/sdp`
                       nullable: true
                       type: string
                     stackableVersion:

--- a/deploy/helm/nifi-operator/values.yaml
+++ b/deploy/helm/nifi-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for nifi-operator.
 ---
 image:
-  repository: docker.stackable.tech/stackable/nifi-operator
+  repository: oci.stackable.tech/sdp/nifi-operator
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/docs/modules/nifi/pages/reference/environment-variables.adoc
+++ b/docs/modules/nifi/pages/reference/environment-variables.adoc
@@ -30,7 +30,7 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/nifi-operator:latest
+oci.stackable.tech/sdp/nifi-operator:0.0.0-dev
 ----
 
 == PRODUCT_CONFIG
@@ -56,7 +56,7 @@ docker run \
     --env KUBECONFIG=/home/stackable/.kube/config \
     --env PRODUCT_CONFIG=/my/product/config.yaml \
     --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-    docker.stackable.tech/stackable/nifi-operator:latest
+    oci.stackable.tech/sdp/nifi-operator:0.0.0-dev
 ----
 
 == WATCH_NAMESPACE
@@ -85,5 +85,5 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env WATCH_NAMESPACE=test \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/nifi-operator:latest
+oci.stackable.tech/sdp/nifi-operator:0.0.0-dev
 ----

--- a/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
+++ b/docs/modules/nifi/pages/usage_guide/custom_processors.adoc
@@ -19,7 +19,7 @@ The basic Dockerfile below shows how to achieve this:
 
 [source,Dockerfile]
 ----
-FROM docker.stackable.tech/stackable/nifi:1.27.0-stackable0.0.0-dev
+FROM oci.stackable.tech/sdp/nifi:1.27.0-stackable0.0.0-dev
 COPY /path/to/your/nar.file /stackable/nifi/lib/
 ----
 

--- a/tests/templates/kuttl/ldap/03-install-test-nifi.yaml
+++ b/tests/templates/kuttl/ldap/03-install-test-nifi.yaml
@@ -17,5 +17,5 @@ spec:
     spec:
       containers:
         - name: test-nifi
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command: ["sleep", "infinity"]

--- a/tests/templates/kuttl/logging/05-install-nifi-test-runner.yaml
+++ b/tests/templates/kuttl/logging/05-install-nifi-test-runner.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: nifi-test-runner
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true

--- a/tests/templates/kuttl/oidc/20-login-test.yaml.j2
+++ b/tests/templates/kuttl/oidc/20-login-test.yaml.j2
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: oidc-login-test
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command: ["python", "/tmp/test-script/login.py"]
           env:
             - name: NAMESPACE

--- a/tests/templates/kuttl/smoke/50-install-test-nifi.yaml
+++ b/tests/templates/kuttl/smoke/50-install-test-nifi.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: test-nifi
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command: ["sleep", "infinity"]
           resources:
             requests:

--- a/tests/templates/kuttl/upgrade/03-install-test-nifi.yaml
+++ b/tests/templates/kuttl/upgrade/03-install-test-nifi.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: test-nifi
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -12,7 +12,7 @@ dimensions:
       - 2.0.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
+      # - 1.27.0,oci.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
   - name: nifi_old
     values:
       - 1.27.0
@@ -21,13 +21,13 @@ dimensions:
       - 2.0.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
+      # - 1.27.0,oci.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
   - name: nifi-latest
     values:
       - 2.0.0
       # Alternatively, if you want to use a custom image, append a comma and the full image name to the product version
       # as in the example below.
-      # - 1.27.0,docker.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
+      # - 1.27.0,oci.stackable.tech/sandbox/nifi:1.27.0-stackable0.0.0-dev
   - name: ldap-use-tls
     values:
       - "false"


### PR DESCRIPTION
# Description

- [x] merge templating PR
- [x] change all references, use search-and-replace to find things (Makefile, Dockerfiles, operator Helm Charts, default,nix, kuttl tests, ....)
- [x] ensure that kuttl tests are running
- [x] for every image reference, ensure that the image is actually in Harbor (and image hash is the same as before?)

```
--- PASS: kuttl (1608.37s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/oidc_zookeeper-latest-3.9.2_nifi-2.0.0_oidc-use-tls-true_openshift-false (98.64s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_nifi-1.27.0_openshift-false_listener-class-cluster-internal (247.56s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.2_nifi-1.27.0_ldap-use-tls-false_openshift-false (181.03s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.2_nifi-2.0.0_ldap-use-tls-true_openshift-false (173.46s)
        --- PASS: kuttl/harness/upgrade_zookeeper-latest-3.9.2_nifi_old-1.27.0_nifi_new-2.0.0_openshift-false (366.96s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.2_nifi-2.0.0_ldap-use-tls-false_openshift-false (179.40s)
        --- PASS: kuttl/harness/orphaned_resources_zookeeper-latest-3.9.2_nifi-1.27.0_openshift-false (156.69s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.2_nifi-1.27.0_ldap-use-tls-true_openshift-false (178.59s)
        --- PASS: kuttl/harness/orphaned_resources_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-false (79.34s)
        --- PASS: kuttl/harness/resources_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-false (98.55s)
        --- PASS: kuttl/harness/logging_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-false (114.74s)
        --- PASS: kuttl/harness/resources_zookeeper-latest-3.9.2_nifi-1.27.0_openshift-false (205.17s)
        --- PASS: kuttl/harness/oidc_zookeeper-latest-3.9.2_nifi-2.0.0_oidc-use-tls-false_openshift-false (84.60s)
        --- PASS: kuttl/harness/cluster_operation_zookeeper-latest-3.9.2_nifi-latest-2.0.0_openshift-false (95.80s)
        --- PASS: kuttl/harness/oidc_zookeeper-latest-3.9.2_nifi-1.27.0_oidc-use-tls-true_openshift-false (104.03s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_nifi-2.0.0_openshift-false_listener-class-external-unstable (171.17s)
        --- PASS: kuttl/harness/logging_zookeeper-latest-3.9.2_nifi-1.27.0_openshift-false (167.63s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_nifi-2.0.0_openshift-false_listener-class-cluster-internal (163.48s)
        --- PASS: kuttl/harness/oidc_zookeeper-latest-3.9.2_nifi-1.27.0_oidc-use-tls-false_openshift-false (98.80s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_nifi-1.27.0_openshift-false_listener-class-external-unstable (245.70s)
PASS
```

Openshift:
```
--- FAIL: kuttl (1001.66s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-true (278.02s)
        --- PASS: kuttl/harness/oidc_zookeeper-latest-3.9.2_nifi-2.0.0_oidc-use-tls-true_openshift-true (129.24s)
        --- FAIL: kuttl/harness/resources_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-true (511.31s)
        --- PASS: kuttl/harness/smoke_zookeeper-3.9.2_nifi-2.0.0_openshift-true_listener-class-external-unstable (159.31s)
        --- PASS: kuttl/harness/ldap_zookeeper-latest-3.9.2_nifi-2.0.0_ldap-use-tls-true_openshift-true (190.87s)
        --- PASS: kuttl/harness/cluster_operation_zookeeper-latest-3.9.2_nifi-latest-2.0.0_openshift-true (95.75s)
        --- PASS: kuttl/harness/orphaned_resources_zookeeper-latest-3.9.2_nifi-2.0.0_openshift-true (59.45s)
        --- PASS: kuttl/harness/upgrade_zookeeper-latest-3.9.2_nifi_old-1.27.0_nifi_new-2.0.0_openshift-true (434.89s)
FAIL
```
All the failed tests completed successfully, seems to be deletion flakyness.
## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
