### PR TITLE
docs: Revert to 1.28.1

### DIFF
--- a/docs/modules/nifi/examples/getting_started/getting_started.sh
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh
@@ -146,7 +146,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
   clusterConfig:
     authentication:
       - authenticationClass: simple-nifi-users

--- a/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
@@ -146,7 +146,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 2.2.0
+    productVersion: 1.28.1
   clusterConfig:
     authentication:
       - authenticationClass: simple-nifi-users

--- a/docs/modules/nifi/partials/supported-versions.adoc
+++ b/docs/modules/nifi/partials/supported-versions.adoc
@@ -2,7 +2,7 @@
 // This is a separate file, since it is used by both the direct NiFi-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-* 2.2.0 Please note that you need to upgrade to at least 1.27.x before upgrading to 2.x.x!
+* 2.2.0 (experimental) - Please note that you need to upgrade to at least 1.27.x before upgrading to 2.x.x!
 * 1.28.1
 * 1.27.0 (LTS)
 


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/966.

It was decided that NiFi 2.x will remainin experimental in SDP 25.3, until there is a way to handle restoring templates/flows.