### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#772]).
 - test: Bump to Vector `0.46.1` ([#789]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#801])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -47,6 +51,7 @@ All notable changes to this project will be documented in this file.
 [#787]: https://github.com/stackabletech/nifi-operator/pull/787
 [#789]: https://github.com/stackabletech/nifi-operator/pull/789
 [#799]: https://github.com/stackabletech/nifi-operator/pull/799
+[#801]: https://github.com/stackabletech/nifi-operator/pull/801
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -107,7 +107,6 @@ use crate::{
 
 pub const NIFI_CONTROLLER_NAME: &str = "nificluster";
 pub const NIFI_FULL_CONTROLLER_NAME: &str = concatcp!(NIFI_CONTROLLER_NAME, '.', OPERATOR_NAME);
-pub const NIFI_UID: i64 = 1000;
 
 const DOCKER_IMAGE_BASE_NAME: &str = "nifi";
 
@@ -1366,13 +1365,7 @@ async fn build_node_rolegroup_statefulset(
         })
         .context(AddVolumeSnafu)?
         .service_account_name(service_account_name)
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(NIFI_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     let mut labels = BTreeMap::new();
     labels.insert(

--- a/rust/operator-binary/src/reporting_task/mod.rs
+++ b/rust/operator-binary/src/reporting_task/mod.rs
@@ -49,7 +49,7 @@ use stackable_operator::{
 };
 
 use crate::{
-    controller::{NIFI_UID, build_recommended_labels},
+    controller::build_recommended_labels,
     crd::{APP_NAME, HTTPS_PORT, HTTPS_PORT_NAME, METRICS_PORT, NifiRole, v1alpha1},
     security::{
         authentication::{NifiAuthenticationConfig, STACKABLE_ADMIN_USERNAME},
@@ -345,13 +345,7 @@ fn build_reporting_task_job(
         .image_pull_secrets_from_product_image(resolved_product_image)
         .restart_policy("OnFailure")
         .service_account_name(sa_name)
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(NIFI_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        )
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build())
         .add_container(cb.build())
         .add_volume(
             build_tls_volume(


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist


### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer
- [x] Changelog updated


### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
