### PR TITLE
fix(docs): Update getting-started script pre-25.7.0

### DIFF
--- a/docs/modules/nifi/examples/getting_started/getting_started.sh
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh
@@ -139,7 +139,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 1.28.1
+    productVersion: 2.4.0
   clusterConfig:
     authentication:
       - authenticationClass: simple-nifi-users

--- a/docs/modules/nifi/examples/getting_started/getting_started.sh
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh
@@ -208,7 +208,7 @@ echo "NiFi web interface: $nifi_url"
 
 echo "Getting NiFi endpoint with stackablectl ..."
 # tag::stackablectl-nifi-url[]
-nifi_url=$(stackablectl stacklet ls -o json | jq --raw-output '.[] | select(.name == "simple-nifi") | .endpoints.https')
+nifi_url=$(stackablectl stacklet ls -o json | jq --raw-output '.[] | select(.name == "simple-nifi") | .endpoints["node-https"]')
 # end::stackablectl-nifi-url[]
 echo "Endpoint: $nifi_url"
 

--- a/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
@@ -139,7 +139,7 @@ metadata:
   name: simple-nifi
 spec:
   image:
-    productVersion: 1.28.1
+    productVersion: 2.4.0
   clusterConfig:
     authentication:
       - authenticationClass: simple-nifi-users

--- a/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/nifi/examples/getting_started/getting_started.sh.j2
@@ -207,7 +207,7 @@ echo "NiFi web interface: $nifi_url"
 
 echo "Getting NiFi endpoint with stackablectl ..."
 # tag::stackablectl-nifi-url[]
-nifi_url=$(stackablectl stacklet ls -o json | jq --raw-output '.[] | select(.name == "simple-nifi") | .endpoints.https')
+nifi_url=$(stackablectl stacklet ls -o json | jq --raw-output '.[] | select(.name == "simple-nifi") | .endpoints["node-https"]')
 # end::stackablectl-nifi-url[]
 echo "Endpoint: $nifi_url"
 

--- a/docs/modules/nifi/partials/supported-versions.adoc
+++ b/docs/modules/nifi/partials/supported-versions.adoc
@@ -2,7 +2,7 @@
 // This is a separate file, since it is used by both the direct NiFi-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-* 2.4.0 (experimental) - Please note that you need to upgrade to at least 1.27.x before upgrading to 2.x.x!
+* 2.4.0 (Please note that you need to upgrade to at least 1.27.x before upgrading to 2.x.x!)
 * 1.28.1
 * 1.27.0 (LTS)
 


### PR DESCRIPTION
- Use NiFi 2.4.0 (fix docs to remove the experimental marker)
- Fix jq query to use new output from stackablectl

## Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of <https://github.com/stackabletech/issues/issues/TRACKING_ISSUE>

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
