### PR TITLE
fix: Add metrics Service SAN to NiFis certificate

### DIFF
--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -109,7 +109,7 @@ use crate::{
     },
     service::{
         build_rolegroup_headless_service, build_rolegroup_metrics_service, metrics_service_port,
-        rolegroup_headless_service_name,
+        rolegroup_headless_service_name, rolegroup_metrics_service_name,
     },
 };
 
@@ -1347,7 +1347,10 @@ async fn build_node_rolegroup_statefulset(
             build_tls_volume(
                 nifi,
                 KEYSTORE_VOLUME_NAME,
-                vec![&build_reporting_task_service_name(&nifi_cluster_name)],
+                [
+                    rolegroup_metrics_service_name(rolegroup_ref.object_name()),
+                    build_reporting_task_service_name(&nifi_cluster_name),
+                ],
                 SecretFormat::TlsPkcs12,
                 &requested_secret_lifetime,
                 Some(LISTENER_VOLUME_NAME),

--- a/rust/operator-binary/src/reporting_task/mod.rs
+++ b/rust/operator-binary/src/reporting_task/mod.rs
@@ -350,7 +350,7 @@ fn build_reporting_task_job(
             build_tls_volume(
                 nifi,
                 REPORTING_TASK_CERT_VOLUME_NAME,
-                vec![],
+                Vec::<String>::new(),
                 SecretFormat::TlsPem,
                 // The certificate is only used for the REST API call, so a short lifetime is sufficient.
                 // There is no correct way to configure this job since it's an implementation detail.

--- a/rust/operator-binary/src/security/mod.rs
+++ b/rust/operator-binary/src/security/mod.rs
@@ -47,7 +47,7 @@ pub async fn check_or_generate_oidc_admin_password(
 pub fn build_tls_volume(
     nifi: &v1alpha1::NifiCluster,
     volume_name: &str,
-    service_scopes: Vec<&str>,
+    service_scopes: impl IntoIterator<Item = impl AsRef<str>>,
     secret_format: SecretFormat,
     requested_secret_lifetime: &Duration,
     listener_scope: Option<&str>,

--- a/rust/operator-binary/src/security/tls.rs
+++ b/rust/operator-binary/src/security/tls.rs
@@ -24,7 +24,7 @@ pub enum Error {
 pub(crate) fn build_tls_volume(
     nifi: &v1alpha1::NifiCluster,
     volume_name: &str,
-    service_scopes: Vec<&str>,
+    service_scopes: impl IntoIterator<Item = impl AsRef<str>>,
     secret_format: SecretFormat,
     requested_secret_lifetime: &Duration,
     listener_scope: Option<&str>,
@@ -36,7 +36,7 @@ pub(crate) fn build_tls_volume(
         secret_volume_source_builder.with_tls_pkcs12_password(STACKABLE_TLS_STORE_PASSWORD);
     }
     for scope in service_scopes {
-        secret_volume_source_builder.with_service_scope(scope);
+        secret_volume_source_builder.with_service_scope(scope.as_ref());
     }
     if let Some(listener_scope) = listener_scope {
         secret_volume_source_builder.with_listener_volume_scope(listener_scope);

--- a/rust/operator-binary/src/service.rs
+++ b/rust/operator-binary/src/service.rs
@@ -127,7 +127,8 @@ pub fn metrics_service_port(product_version: &str) -> ServicePort {
 }
 
 /// Returns the metrics rolegroup service name `<cluster>-<role>-<rolegroup>-<METRICS_SERVICE_SUFFIX>`.
-fn rolegroup_metrics_service_name(role_group_ref_object_name: &str) -> String {
+pub fn rolegroup_metrics_service_name(role_group_ref_object_name: impl AsRef<str>) -> String {
+    let role_group_ref_object_name = role_group_ref_object_name.as_ref();
     format!("{role_group_ref_object_name}-{METRICS_SERVICE_SUFFIX}")
 }
 


### PR DESCRIPTION
Before
 `Subject Alternative Names: simple-nifi-reporting-task.default.svc.cluster.local, IP Address:172.20.0.2, simple-nifi-node-default-headless.default.svc.cluster.local, simple-nifi-node-default-0.simple-nifi-node-default-headless.default.svc.cluster.local`
After
`Subject Alternative Names: simple-nifi-node-default-metrics.default.svc.cluster.local, simple-nifi-reporting-task.default.svc.cluster.local, IP Address:172.20.0.2, simple-nifi-node-default-headless.default.svc.cluster.local, simple-nifi-node-default-0.simple-nifi-node-default-headless.default.svc.cluster.local`

We can now curl the metrics (cert shoukd match, *no* SNI check failure)
`curl -k https://simple-nifi-node-default-metrics.default.svc.cluster.local:8443/nifi-api/flow/metrics/prometheus` works as in returns a 401 (excpected)
