### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -164,6 +164,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
   # Required for Kubernetes-managed clustering, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-clustering
   - apiGroups:
       - coordination.k8s.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
