### PR TITLE
refactor: Don't modify ContainerBuilder after it has been build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,9 +3251,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.5"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec961601b32b6f5d14ae8dabd35ff2ff2e2c6cb4c0e6641845ff105abe96d958"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10809,9 +10809,9 @@ rec {
       };
       "url" = rec {
         crateName = "url";
-        version = "2.5.5";
+        version = "2.5.7";
         edition = "2018";
-        sha256 = "0n6rjsz5l47z8lc69rn0nin2qbpzy9gx7awdmqa5svrbnc0id5pc";
+        sha256 = "0nzghdv0kcksyvri0npxbjzyx2ihprks5k590y77bld355m17g08";
         authors = [
           "The rust-url developers"
         ];
@@ -10852,7 +10852,7 @@ rec {
         features = {
           "default" = [ "std" ];
           "serde" = [ "dep:serde" ];
-          "std" = [ "idna/std" "percent-encoding/std" "form_urlencoded/std" ];
+          "std" = [ "idna/std" "percent-encoding/std" "form_urlencoded/std" "serde/std" ];
         };
         resolvedDefaultFeatures = [ "default" "serde" "std" ];
       };

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ snafu = "0.8"
 strum = { version = "0.27", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"
-url = { version = "2.5.2" }
+url = { version = "2.5.7" }
 xml-rs = "0.8"
 
 # [patch."https://github.com/stackabletech/operator-rs.git"]

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1226,8 +1226,8 @@ async fn build_node_rolegroup_statefulset(
         .context(AddVolumeMountSnafu)?;
 
     // We want to add nifi container first for easier defaulting into this container
-    // After calling `build()` the ContainerBuilder shouldn't be used anymore, so we drop it
     pod_builder.add_container(container_nifi.build());
+    // After calling `build()` the ContainerBuilder shouldn't be used anymore, so we drop it
     drop(container_nifi_builder);
 
     for container in git_sync_resources.git_sync_containers.iter().cloned() {

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1240,10 +1240,6 @@ async fn build_node_rolegroup_statefulset(
         .add_volumes(git_sync_resources.git_content_volumes.to_owned())
         .context(AddVolumeSnafu)?;
 
-    authentication_config
-        .add_volumes_and_mounts(&mut pod_builder, vec![&mut container_prepare])
-        .context(AddAuthVolumesSnafu)?;
-
     if let Some(ContainerLogConfig {
         choice:
             Some(ContainerLogConfigChoice::Custom(CustomContainerLogConfig {
@@ -1299,6 +1295,10 @@ async fn build_node_rolegroup_statefulset(
             }
         }
     }
+
+    authentication_config
+        .add_volumes_and_mounts(&mut pod_builder, vec![&mut container_prepare])
+        .context(AddAuthVolumesSnafu)?;
 
     let metadata = ObjectMetaBuilder::new()
         .with_recommended_labels(build_recommended_labels(

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1220,6 +1220,13 @@ async fn build_node_rolegroup_statefulset(
         .add_volume_mount(&volume_name, NIFI_PYTHON_WORKING_DIRECTORY)
         .context(AddVolumeMountSnafu)?;
 
+    authentication_config
+        .add_volumes_and_mounts(
+            &mut pod_builder,
+            vec![&mut container_prepare, container_nifi],
+        )
+        .context(AddAuthVolumesSnafu)?;
+
     container_nifi
         .add_volume_mounts(git_sync_resources.git_content_volume_mounts.to_owned())
         .context(AddVolumeMountSnafu)?;
@@ -1292,13 +1299,6 @@ async fn build_node_rolegroup_statefulset(
             }
         }
     }
-
-    authentication_config
-        .add_volumes_and_mounts(
-            &mut pod_builder,
-            vec![&mut container_prepare, container_nifi],
-        )
-        .context(AddAuthVolumesSnafu)?;
 
     let metadata = ObjectMetaBuilder::new()
         .with_recommended_labels(build_recommended_labels(

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -1064,11 +1064,12 @@ async fn build_node_rolegroup_statefulset(
         );
 
     let nifi_container_name = Container::Nifi.to_string();
-    let mut container_builder = ContainerBuilder::new(&nifi_container_name).with_context(|_| {
-        IllegalContainerNameSnafu {
-            container_name: nifi_container_name,
-        }
-    })?;
+    let mut container_nifi_builder =
+        ContainerBuilder::new(&nifi_container_name).with_context(|_| {
+            IllegalContainerNameSnafu {
+                container_name: nifi_container_name,
+            }
+        })?;
 
     let nifi_args = vec![formatdoc! {"
             {COMMON_BASH_TRAP_FUNCTIONS}
@@ -1084,7 +1085,7 @@ async fn build_node_rolegroup_statefulset(
     create_vector_shutdown_file_command =
         create_vector_shutdown_file_command(STACKABLE_LOG_DIR),
     }];
-    let container_nifi = container_builder
+    let container_nifi = container_nifi_builder
         .image_from_product_image(resolved_product_image)
         .command(vec![
             "/bin/bash".to_string(),
@@ -1220,19 +1221,14 @@ async fn build_node_rolegroup_statefulset(
         .add_volume_mount(&volume_name, NIFI_PYTHON_WORKING_DIRECTORY)
         .context(AddVolumeMountSnafu)?;
 
-    authentication_config
-        .add_volumes_and_mounts(
-            &mut pod_builder,
-            vec![&mut container_prepare, container_nifi],
-        )
-        .context(AddAuthVolumesSnafu)?;
-
     container_nifi
         .add_volume_mounts(git_sync_resources.git_content_volume_mounts.to_owned())
         .context(AddVolumeMountSnafu)?;
 
     // We want to add nifi container first for easier defaulting into this container
+    // After calling `build()` the ContainerBuilder shouldn't be used anymore, so we drop it
     pod_builder.add_container(container_nifi.build());
+    drop(container_nifi_builder);
 
     for container in git_sync_resources.git_sync_containers.iter().cloned() {
         pod_builder.add_container(container);
@@ -1243,6 +1239,10 @@ async fn build_node_rolegroup_statefulset(
     pod_builder
         .add_volumes(git_sync_resources.git_content_volumes.to_owned())
         .context(AddVolumeSnafu)?;
+
+    authentication_config
+        .add_volumes_and_mounts(&mut pod_builder, vec![&mut container_prepare])
+        .context(AddAuthVolumesSnafu)?;
 
     if let Some(ContainerLogConfig {
         choice:


### PR DESCRIPTION
## Description

~~During reconciliation the moved code from the PR was called after `pod_builder.add_container(container_nifi.build())`, therefore not updating the volumeMounts of the `nifi` container with the volumeMounts related to the authentication config and they were missing. This PR adds them in.~~

After talking with @sbernauer: The prepare container was configuring things with the auth configs being mounted, so the code/tests still worked as expected.

But hence the volumeMounts are not needed on the nifi container (which weren't applied anyway due to the crossed out explanation above). The correct way would be to remove the ContainerBuilder from the mounting step.

Adjusted the code to reflect that, also renamed and dropped the ContainerBuilder for code clarity. Will run integrationtests to make sure everything works and add them into the description.

Integrationtests
```
--- FAIL: kuttl (4999.48s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false (233.71s)
        --- PASS: kuttl/harness/upgrade_nifi_old-1.27.0_nifi_new-2.4.0_zookeeper-latest-3.9.3_openshift-false (413.86s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.28.1_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-true_openshift-false (230.47s)
        --- PASS: kuttl/harness/resources_nifi-2.4.0_zookeeper-latest-3.9.3_openshift-false (79.36s)
        --- PASS: kuttl/harness/resources_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false (195.59s)
        --- PASS: kuttl/harness/resources_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false (206.26s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (260.61s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (382.25s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (379.22s)
        --- PASS: kuttl/harness/oidc-opa_nifi-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-true_openshift-false (170.94s)
        --- PASS: kuttl/harness/oidc-opa_nifi-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-false_openshift-false (187.98s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-2.4.0_zookeeper-latest-3.9.3_openshift-false (164.27s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (176.55s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (293.72s)
        --- FAIL: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (1286.15s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (176.24s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (164.81s)
        --- PASS: kuttl/harness/external-access_nifi-2.4.0_zookeeper-latest-3.9.3_openshift-false (72.06s)
        --- FAIL: kuttl/harness/external-access_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false (386.51s)
        --- FAIL: kuttl/harness/external-access_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false (391.46s)
        --- PASS: kuttl/harness/cluster_operation_nifi-latest-2.4.0_zookeeper-latest-3.9.3_openshift-false (101.90s)
        --- PASS: kuttl/harness/logging_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false (179.48s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false (170.39s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false (182.79s)
        --- PASS: kuttl/harness/logging_nifi-2.4.0_zookeeper-latest-3.9.3_openshift-false (106.74s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-476_krb5-1.21.1_iceberg-use-kerberos-false_kerberos-realm-PROD.MYCORP_openshift-false (570.09s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-476_krb5-1.21.1_iceberg-use-kerberos-true_kerberos-realm-PROD.MYCORP_openshift-false (396.09s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-2.4.0_zookeeper-latest-3.9.3_openshift-false (82.99s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false (215.82s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (226.82s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.28.1_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-false_openshift-false (191.28s)
        --- PASS: kuttl/harness/logging_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false (153.87s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.27.0_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-true_openshift-false (199.17s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.27.0_zookeeper-latest-3.9.3_opa-l-1.4.2_oidc-use-tls-false_openshift-false (181.15s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (210.33s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (258.89s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (188.57s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (189.44s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (194.16s)
FAIL

--- PASS: kuttl (359.32s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (359.31s)
PASS

    logger.go:42: 08:48:13 | external-access_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false/30-install-nifi | nificluster.nifi.stackable.tech/test-nifi condition met
    logger.go:42: 08:48:13 | external-access_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false/30-install-nifi | test step completed 30-install-nifi
    logger.go:42: 08:48:13 | external-access_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false | skipping kubernetes event logging
    logger.go:42: 08:48:13 | external-access_nifi-1.28.1_zookeeper-latest-3.9.3_openshift-false | Deleting namespace: kuttl-test-stunning-pelican
    case.go:118: context deadline exceeded

    logger.go:42: 08:56:16 | external-access_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false/30-install-nifi | nificluster.nifi.stackable.tech/test-nifi condition met
    logger.go:42: 08:56:16 | external-access_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false/30-install-nifi | test step completed 30-install-nifi
    logger.go:42: 08:56:16 | external-access_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false | skipping kubernetes event logging
    logger.go:42: 08:56:16 | external-access_nifi-1.27.0_zookeeper-latest-3.9.3_openshift-false | Deleting namespace: kuttl-test-unbiased-marmoset
    case.go:118: context deadline exceeded

Succeeded but timed out on deleting namespace
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
