### PR TITLE
fix: Prevent missing certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Previously we had a bug that could lead to missing certificates ([#XXX]).
+- Previously we had a bug that could lead to missing certificates ([#844]).
 
   This could be the case when you specified multiple CAs in your SecretClass.
   We now correctly handle multiple certificates in this cases.
   See [this GitHub issue](https://github.com/stackabletech/issues/issues/764) for details
 
 [#840]: https://github.com/stackabletech/nifi-operator/pull/840
+[#844]: https://github.com/stackabletech/nifi-operator/pull/844
 
 ## [25.7.0] - 2025-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - Helm: Allow Pod `priorityClassName` to be configured ([#840]).
 
+### Fixed
+
+- Previously we had a bug that could lead to missing certificates ([#XXX]).
+
+  This could be the case when you specified multiple CAs in your SecretClass.
+  We now correctly handle multiple certificates in this cases.
+  See [this GitHub issue](https://github.com/stackabletech/issues/issues/764) for details
+
 [#840]: https://github.com/stackabletech/nifi-operator/pull/840
 
 ## [25.7.0] - 2025-07-23

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -951,6 +951,9 @@ async fn build_node_rolegroup_statefulset(
         ));
     }
 
+    // Note(sbernauer): In https://github.com/stackabletech/issues/issues/764 we migrated all usages
+    // of keytool to our own cert-utils tool. As it uses the same code as secret-operator, it also
+    // uses RC2. Thus, the keytool usage here LGTM (no alias trickery) and has my nod of approval.
     prepare_args.extend(vec![
         // The source directory is a secret-op mount and we do not want to write / add anything in there
         // Therefore we import all the contents to a truststore in "writeable" empty dirs.

--- a/tests/templates/kuttl/external-access/30-assert.yaml
+++ b/tests/templates/kuttl/external-access/30-assert.yaml
@@ -3,9 +3,9 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-nifi
-timeout: 300
+timeout: 1200
 commands:
-  - script: kubectl -n $NAMESPACE wait --for=condition=available=true nificlusters.nifi.stackable.tech/test-nifi --timeout 301s
+  - script: kubectl -n $NAMESPACE wait --for=condition=available=true nificlusters.nifi.stackable.tech/test-nifi --timeout 1201s
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/ldap/03-assert.yaml
+++ b/tests/templates/kuttl/ldap/03-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 1200
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/smoke_v1/50-assert.yaml
+++ b/tests/templates/kuttl/smoke_v1/50-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 1200
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/smoke_v2/50-assert.yaml
+++ b/tests/templates/kuttl/smoke_v2/50-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 1200
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/templates/kuttl/upgrade/03-assert.yaml
+++ b/tests/templates/kuttl/upgrade/03-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 1200
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/764.

The server TLS truststore handling was actually fine and left as-is. Only LDAP and OIDC ca cert handling was affected.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
