### PR TITLE
chore: update tests to use bitnamilegacy

### DIFF
--- a/tests/templates/kuttl/iceberg/25_helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/iceberg/25_helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   extendedConfiguration: |

--- a/tests/templates/kuttl/ldap/install-openldap.yaml.j2
+++ b/tests/templates/kuttl/ldap/install-openldap.yaml.j2
@@ -39,7 +39,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.5
+          image: docker.io/bitnamilegacy/openldap:2.5
           env:
             - name: LDAP_ADMIN_USERNAME
               value: admin


### PR DESCRIPTION
## Description

This was missed during the bitnami migration. Part of https://github.com/stackabletech/issues/issues/749 Quickfix.
This PR updates the tests to use the bitnamilegacy repository for bitnami images. All affected tests ran successfully.

```
--- FAIL: kuttl (1176.73s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (462.91s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (467.93s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (278.90s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.3_ldap-use-tls-false_openshift-false (200.78s)
        --- FAIL: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (534.09s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (229.10s)
FAIL

--- PASS: kuttl (209.71s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.3_ldap-use-tls-true_openshift-false (209.69s)
PASS

--- PASS: kuttl (593.59s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-476_krb5-1.21.1_iceberg-use-kerberos-false_kerberos-realm-PROD.MYCORP_openshift-false (541.88s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.3_opa-l-1.4.2_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-476_krb5-1.21.1_iceberg-use-kerberos-true_kerberos-realm-PROD.MYCORP_openshift-false (593.58s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
