### PR TITLE
chore: Bump Trino to 477 in test definition

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -53,7 +53,7 @@ dimensions:
       - 4.0.1
   - name: trino-l
     values:
-      - "476"
+      - "477"
   - name: krb5
     values:
       - 1.21.1


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1242