### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/examples/simple-nifi-cluster.yaml
+++ b/examples/simple-nifi-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/iceberg/40-create-iceberg-tables.j2
+++ b/tests/templates/kuttl/iceberg/40-create-iceberg-tables.j2
@@ -15,7 +15,7 @@ spec:
             - pipefail
             - -c
             - |
-              cat << 'EOF' | java -jar trino-cli-*-executable.jar --server https://trino-coordinator:8443 --insecure --user admin
+              cat << 'EOF' | ./trino-cli --server https://trino-coordinator:8443 --insecure --user admin
               CREATE SCHEMA IF NOT EXISTS iceberg.s3 WITH (location = 's3a://demo/lakehouse/s3');
               CREATE TABLE IF NOT EXISTS iceberg.s3.greetings (hello varchar);
               CREATE SCHEMA IF NOT EXISTS iceberg.hdfs WITH (location = 'hdfs:/lakehouse/hdfs');

--- a/tests/templates/kuttl/iceberg/70-check-iceberg-tables.yaml.j2
+++ b/tests/templates/kuttl/iceberg/70-check-iceberg-tables.yaml.j2
@@ -16,7 +16,7 @@ spec:
             - -c
             - |
               for SCHEMA in iceberg.s3 iceberg.hdfs; do
-                COUNT=$(cat << EOF | java -jar trino-cli-*-executable.jar --server https://trino-coordinator:8443 --insecure --user admin
+                COUNT=$(cat << EOF | ./trino-cli --server https://trino-coordinator:8443 --insecure --user admin
                 SELECT COUNT(*) FROM $SCHEMA.greetings WHERE hello = 'world from NiFi :)';
               EOF
                 )

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -39,9 +39,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: opa-l
     values:
       - 1.8.0


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (7047.56s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (561.74s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (368.79s)
        --- FAIL: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-477_krb5-1.21.1_iceberg-use-kerberos-false_kerberos-realm-PROD.MYCORP_openshift-false (947.63s)
        --- PASS: kuttl/harness/oidc-opa_nifi-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-false_openshift-false (443.01s)
        --- PASS: kuttl/harness/oidc-opa_nifi-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-true_openshift-false (467.76s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.28.1_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-false_openshift-false (362.88s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.28.1_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-true_openshift-false (457.65s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.27.0_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-true_openshift-false (362.89s)
        --- PASS: kuttl/harness/oidc-opa_nifi-1.27.0_zookeeper-latest-3.9.4_opa-l-1.8.0_oidc-use-tls-false_openshift-false (329.83s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (256.54s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (336.75s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (73.81s)
        --- PASS: kuttl/harness/custom-components-git-sync_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (211.41s)
        --- PASS: kuttl/harness/external-access_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (85.20s)
        --- PASS: kuttl/harness/logging_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (181.55s)
        --- FAIL: kuttl/harness/external-access_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (439.12s)
        --- FAIL: kuttl/harness/external-access_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (416.06s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (214.73s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (193.15s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (214.82s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-true_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (220.42s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (202.55s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (213.82s)
        --- PASS: kuttl/harness/logging_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (203.20s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (275.07s)
        --- PASS: kuttl/harness/logging_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (211.37s)
        --- PASS: kuttl/harness/cluster_operation_nifi-latest-2.4.0_zookeeper-latest-3.9.4_openshift-false (145.73s)
        --- PASS: kuttl/harness/upgrade_nifi_old-1.27.0_nifi_new-2.4.0_zookeeper-latest-3.9.4_openshift-false (452.99s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (286.10s)
        --- FAIL: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (261.23s)
        --- FAIL: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (43.97s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (221.73s)
        --- PASS: kuttl/harness/smoke_v2_nifi-v2-2.4.0_use-zookeeper-manager-false_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (242.16s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.4_ldap-use-tls-false_openshift-false (216.01s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (428.99s)
        --- PASS: kuttl/harness/resources_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (98.25s)
        --- PASS: kuttl/harness/orphaned_resources_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (255.14s)
        --- PASS: kuttl/harness/resources_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (280.77s)
        --- PASS: kuttl/harness/resources_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (306.00s)
        --- PASS: kuttl/harness/ldap_nifi-2.4.0_zookeeper-latest-3.9.4_ldap-use-tls-true_openshift-false (230.51s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.4_ldap-use-tls-true_openshift-false (246.38s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.4_ldap-use-tls-false_openshift-false (231.05s)
        --- PASS: kuttl/harness/ldap_nifi-1.28.1_zookeeper-latest-3.9.4_ldap-use-tls-false_openshift-false (272.03s)
        --- PASS: kuttl/harness/ldap_nifi-1.27.0_zookeeper-latest-3.9.4_ldap-use-tls-true_openshift-false (245.49s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (256.20s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (279.92s)
        --- FAIL: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-477_krb5-1.21.1_iceberg-use-kerberos-true_kerberos-realm-PROD.MYCORP_openshift-false (650.65s)
FAIL

--- PASS: kuttl (566.35s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-477_krb5-1.21.1_iceberg-use-kerberos-true_kerberos-realm-PROD.MYCORP_openshift-false (493.35s)
        --- PASS: kuttl/harness/iceberg_nifi-iceberg-2.4.0_zookeeper-latest-3.9.4_opa-l-1.8.0_hdfs-l-3.4.1_hive-l-4.0.1_trino-l-477_krb5-1.21.1_iceberg-use-kerberos-false_kerberos-realm-PROD.MYCORP_openshift-false (566.34s)
PASS

--- FAIL: kuttl (530.73s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/external-access_nifi-2.4.0_zookeeper-latest-3.9.4_openshift-false (92.95s)
        --- FAIL: kuttl/harness/external-access_nifi-1.27.0_zookeeper-latest-3.9.4_openshift-false (425.47s)
        --- FAIL: kuttl/harness/external-access_nifi-1.28.1_zookeeper-latest-3.9.4_openshift-false (437.77s)
FAIL
external-access tests succeeded, just timed out on namespace deletion

--- PASS: kuttl (1367.13s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (401.18s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-cluster-internal (403.45s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (273.74s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (281.83s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.28.1_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (294.69s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.4_openshift-false_listener-class-cluster-internal (381.41s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.4_openshift-false_listener-class-external-unstable (287.55s)
        --- PASS: kuttl/harness/smoke_v1_nifi-v1-1.27.0_zookeeper-3.9.3_openshift-false_listener-class-external-unstable (300.43s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
