### PR TITLE
chore: Describe RBAC rules, remove unnecessary rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Helm deployed RBAC permissions documented, with unnecessary permissions removed ([#916]).
+
+[#916]: https://github.com/stackabletech/nifi-operator/pull/916
+
 ## [26.3.0] - 2026-03-16
 
 ## [26.3.0-rc1] - 2026-03-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Helm deployed RBAC permissions documented, with unnecessary permissions removed ([#916]).
+- Document Helm deployed RBAC permissions and remove unnecessary permissions ([#916]).
 
 [#916]: https://github.com/stackabletech/nifi-operator/pull/916
 

--- a/deploy/helm/nifi-operator/templates/clusterrole-operator.yaml
+++ b/deploy/helm/nifi-operator/templates/clusterrole-operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -163,46 +164,3 @@ rules:
       - get
       - list
       - watch
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "operator.name" . }}-clusterrole
-  labels:
-  {{- include "operator.labels" . | nindent 4 }}
-rules:
-  # Required for Kubernetes-managed clustering, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-clustering
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - update
-      # undocumented but required
-      - patch
-  # Required for Kubernetes cluster state provider, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-configmap-cluster-state-provider
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
-  # Required to use the nonroot-v2 SCC on OpenShift
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    resourceNames:
-      - nonroot-v2
-    verbs:
-      - use
-{{ end }}

--- a/deploy/helm/nifi-operator/templates/clusterrole-product.yaml
+++ b/deploy/helm/nifi-operator/templates/clusterrole-product.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "operator.name" . }}-clusterrole
+  labels:
+  {{- include "operator.labels" . | nindent 4 }}
+rules:
+  # Required for Kubernetes-managed clustering, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-clustering
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+      # undocumented but required
+      - patch
+  # Required for Kubernetes cluster state provider, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-configmap-cluster-state-provider
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+{{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+  # Required to use the nonroot-v2 SCC on OpenShift
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - nonroot-v2
+    verbs:
+      - use
+{{ end }}

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -101,6 +101,7 @@ rules:
       - get
       - list
       - patch
+  # customresourcedefinitions: read to check CRD existence; patched to maintain the conversion webhook certificate
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -189,6 +190,7 @@ rules:
       - configmaps
     verbs:
       - get
+  # For emitting Kubernetes Events
   - apiGroups:
       - events.k8s.io
     resources:
@@ -220,6 +222,7 @@ rules:
       - patch
       - update
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+  # Required to use the nonroot-v2 SCC on OpenShift
   - apiGroups:
       - security.openshift.io
     resources:

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -13,11 +13,7 @@ rules:
     verbs:
       - get
   # Manage core workload resources created per NifiCluster.
-  # All resources are applied via Server-Side Apply (create + patch), fetched when
-  # reconciliation is paused (get), and tracked for orphan cleanup (list + delete).
-  # configmaps: rolegroup configuration; watched by the controller via .owns()/.watches()
-  # services: rolegroup headless/metrics services and optional reporting-task service;
-  #   watched by the controller via .owns()
+  # Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - ""
     resources:
@@ -30,8 +26,8 @@ rules:
       - list
       - patch
       - watch
-  # serviceaccounts: one ServiceAccount per NifiCluster (built by build_rbac_resources);
-  #   applied via SSA + orphan cleanup; not watched by the controller
+  # ServiceAccount created per NifiCluster for workload pod identity.
+  # Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - ""
     resources:
@@ -42,9 +38,7 @@ rules:
       - get
       - list
       - patch
-  # secrets: sensitive-properties key and (when OIDC) admin-password secret;
-  #   looked up with get_opt and created with client.create() — not tracked by
-  #   cluster_resources, so no list/delete needed
+  # Sensitive properties key and (when OIDC) admin password secret.
   - apiGroups:
       - ""
     resources:
@@ -52,8 +46,8 @@ rules:
     verbs:
       - get
       - create
-  # rolebindings: one RoleBinding per NifiCluster (built by build_rbac_resources);
-  #   applied via SSA + orphan cleanup; not watched by the controller
+  # RoleBinding created per NifiCluster to bind the product ClusterRole to the workload
+  # ServiceAccount. Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -64,8 +58,8 @@ rules:
       - get
       - list
       - patch
-  # statefulsets: one StatefulSet per role group; applied via SSA + orphan cleanup;
-  #   watched by the controller via .owns()
+  # StatefulSet created per role group. Applied via SSA, tracked for orphan cleanup, and
+  # owned by the controller.
   - apiGroups:
       - apps
     resources:
@@ -77,8 +71,7 @@ rules:
       - list
       - patch
       - watch
-  # jobs: optional reporting-task Job created when spec.clusterConfig.createReportingTaskJob
-  #   is enabled (NiFi 1.x only); applied via SSA + orphan cleanup; not watched by the controller
+  # Optional reporting-task Job (NiFi 1.x only). Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - batch
     resources:
@@ -89,8 +82,7 @@ rules:
       - get
       - list
       - patch
-  # poddisruptionbudgets: one PDB per NifiCluster role (when pdb.enabled);
-  #   applied via SSA + orphan cleanup; not watched by the controller
+  # PodDisruptionBudget created per role. Applied via SSA and tracked for orphan cleanup.
   - apiGroups:
       - policy
     resources:
@@ -101,7 +93,8 @@ rules:
       - get
       - list
       - patch
-  # customresourcedefinitions: patched to maintain the conversion webhook certificate
+  # Required for maintaining the CRDs within the operator (including the conversion webhook info).
+  # Also for the startup condition check before the controller can run.
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -116,7 +109,7 @@ rules:
       # Required for startup condition
       - list
       - watch
-  # For reporting controller reconciliation results as Kubernetes Events
+  # Required to report reconciliation results and warnings back to the NifiCluster object.
   - apiGroups:
       - events.k8s.io
     resources:
@@ -124,8 +117,8 @@ rules:
     verbs:
       - create
       - patch
-  # listeners: one Listener per NifiCluster role (via build_group_listener);
-  #   applied via SSA + orphan cleanup; not watched by the controller
+  # Listener created per role group for external access. Applied via SSA and tracked for orphan
+  # cleanup.
   - apiGroups:
       - listeners.stackable.tech
     resources:
@@ -136,7 +129,7 @@ rules:
       - get
       - list
       - patch
-  # Primary CRD: list + watch for the controller, get for direct lookups
+  # Primary CRD: watched by the controller and read during reconciliation.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
@@ -145,14 +138,14 @@ rules:
       - get
       - list
       - watch
-  # Status subresource: patched via client.apply_patch_status() after each reconciliation
+  # Status subresource: updated at the end of every reconciliation.
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
-  # AuthenticationClass: read for resolving authentication configuration
+  # Read authentication class configuration referenced in the NifiCluster spec.
   - apiGroups:
       - authentication.stackable.tech
     resources:

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -5,13 +5,6 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - list
-      - watch
   # For automatic cluster domain detection
   - apiGroups:
       - ""
@@ -19,14 +12,29 @@ rules:
       - nodes/proxy
     verbs:
       - get
+  # Manage core workload resources created per NifiCluster.
+  # All resources are applied via Server-Side Apply (create + patch), fetched when
+  # reconciliation is paused (get), and tracked for orphan cleanup (list + delete).
+  # configmaps: rolegroup configuration; watched by the controller via .owns()/.watches()
+  # services: rolegroup headless/metrics services and optional reporting-task service;
+  #   watched by the controller via .owns()
   - apiGroups:
       - ""
     resources:
-      - pods
       - configmaps
       - services
-      - endpoints
-      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  # serviceaccounts: one ServiceAccount per NifiCluster (built by build_rbac_resources);
+  #   applied via SSA + orphan cleanup; not watched by the controller
+  - apiGroups:
+      - ""
+    resources:
       - serviceaccounts
     verbs:
       - create
@@ -34,8 +42,18 @@ rules:
       - get
       - list
       - patch
-      - update
-      - watch
+  # secrets: sensitive-properties key and (when OIDC) admin-password secret;
+  #   looked up with get_opt and created with client.create() — not tracked by
+  #   cluster_resources, so no list/delete needed
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+  # rolebindings: one RoleBinding per NifiCluster (built by build_rbac_resources);
+  #   applied via SSA + orphan cleanup; not watched by the controller
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -46,20 +64,21 @@ rules:
       - get
       - list
       - patch
-      - update
-      - watch
+  # statefulsets: one StatefulSet per role group; applied via SSA + orphan cleanup;
+  #   watched by the controller via .owns()
   - apiGroups:
       - apps
     resources:
       - statefulsets
     verbs:
-      - get
       - create
       - delete
+      - get
       - list
       - patch
-      - update
       - watch
+  # jobs: optional reporting-task Job created when spec.clusterConfig.createReportingTaskJob
+  #   is enabled (NiFi 1.x only); applied via SSA + orphan cleanup; not watched by the controller
   - apiGroups:
       - batch
     resources:
@@ -70,8 +89,8 @@ rules:
       - get
       - list
       - patch
-      - update
-      - watch
+  # poddisruptionbudgets: one PDB per NifiCluster role (when pdb.enabled);
+  #   applied via SSA + orphan cleanup; not watched by the controller
   - apiGroups:
       - policy
     resources:
@@ -82,8 +101,6 @@ rules:
       - get
       - list
       - patch
-      - update
-      - watch
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -99,6 +116,7 @@ rules:
       - list
       - watch
       {{- end }}
+  # For reporting controller reconciliation results as Kubernetes Events
   - apiGroups:
       - events.k8s.io
     resources:
@@ -106,17 +124,19 @@ rules:
     verbs:
       - create
       - patch
+  # listeners: one Listener per NifiCluster role (via build_group_listener);
+  #   applied via SSA + orphan cleanup; not watched by the controller
   - apiGroups:
       - listeners.stackable.tech
     resources:
       - listeners
     verbs:
-      - get
-      - list
-      - watch
-      - patch
       - create
       - delete
+      - get
+      - list
+      - patch
+  # Primary CRD: list + watch for the controller, get for direct lookups
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
@@ -124,14 +144,15 @@ rules:
     verbs:
       - get
       - list
-      - patch
       - watch
+  # Status subresource: patched via client.apply_patch_status() after each reconciliation
   - apiGroups:
       - {{ include "operator.name" . }}.stackable.tech
     resources:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
+  # AuthenticationClass: read for resolving authentication configuration
   - apiGroups:
       - authentication.stackable.tech
     resources:
@@ -140,6 +161,7 @@ rules:
       - get
       - list
       - watch
+  # Required to bind the product ClusterRole to per-cluster ServiceAccounts
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -58,6 +58,15 @@ rules:
       - get
       - list
       - patch
+  # Required to bind the product ClusterRole to per-cluster ServiceAccounts
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    verbs:
+      - bind
+    resourceNames:
+      - {{ include "operator.name" . }}-clusterrole
   # StatefulSet created per role group. Applied via SSA, tracked for orphan cleanup, and
   # owned by the controller.
   - apiGroups:
@@ -154,15 +163,6 @@ rules:
       - get
       - list
       - watch
-  # Required to bind the product ClusterRole to per-cluster ServiceAccounts
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterroles
-    verbs:
-      - bind
-    resourceNames:
-      - {{ include "operator.name" . }}-clusterrole
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -179,16 +179,6 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-      - serviceaccounts
-      # This is redundant with the rule for specifically about configmaps
-      # (due to clustering), but we read them for other purposes too
-      - configmaps
-    verbs:
-      - get
   # For emitting Kubernetes Events
   - apiGroups:
       - events.k8s.io

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -112,10 +112,10 @@ rules:
       {{- if .Values.maintenance.customResourceDefinitions.maintain }}
       - create
       - patch
+      {{- end }}
       # Required for startup condition
       - list
       - watch
-      {{- end }}
   # For reporting controller reconciliation results as Kubernetes Events
   - apiGroups:
       - events.k8s.io

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -172,14 +172,6 @@ metadata:
   labels:
   {{- include "operator.labels" . | nindent 4 }}
 rules:
-  # For emitting Kubernetes Events
-  - apiGroups:
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
   # Required for Kubernetes-managed clustering, see https://nifi.apache.org/nifi-docs/administration-guide.html#kubernetes-clustering
   - apiGroups:
       - coordination.k8s.io

--- a/deploy/helm/nifi-operator/templates/roles.yaml
+++ b/deploy/helm/nifi-operator/templates/roles.yaml
@@ -101,13 +101,12 @@ rules:
       - get
       - list
       - patch
-  # customresourcedefinitions: read to check CRD existence; patched to maintain the conversion webhook certificate
+  # customresourcedefinitions: patched to maintain the conversion webhook certificate
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs:
-      - get
       # Required to maintain the CRD. The operator needs to do this, as it needs to enter e.g. it's
       # generated certificate in the conversion webhook.
       {{- if .Values.maintenance.customResourceDefinitions.maintain }}


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/798

> [!NOTE]
> This was initially generated by a coding assistant to see how well it can inspect code and _review the RBAC rules_. the changes will be properly checked before reviews are requested.

- [x] Document each rule
- [x] Check the docs make sense. Rewrite where necessary
- [x] Remove unnecessary permissions
- [x] Attach explanations to PR description
- [x] Run all tests
- [x] Split operator and product roles into separate files

## Operator ClusterRole (`{fullname}-clusterrole`)

### Rules removed entirely

| Resource | Verbs removed | Reason |
|---|---|---|
| `nodes` | `list, watch` | Boilerplate from operator-templating (4 years old). `KubernetesClusterInfo` only uses `nodes/proxy: get` for cluster domain detection — no node listing or watching anywhere in the controller |
| `endpoints` | `create, delete, get, list, patch, update, watch` | Auto-created by Kubernetes for Services; the operator never manages endpoints directly |
| `pods` | `create, delete, get, list, patch, update, watch` | StatefulSets create pods; the operator never manages pods directly in the operator role |

### `update` verb removed from all rules

SSA (`apply_patch`) uses HTTP PATCH, not HTTP PUT. `client.update()` is never called anywhere in the operator source.

### `watch` removed from resources not watched by the controller

| Resource | Reason |
|---|---|
| `serviceaccounts` | Applied via `cluster_resources.add()` + orphan cleanup, but not watched via `.owns()` or `.watches()` in `main.rs` |
| `rolebindings` | Same as above |
| `batch/jobs` | Same as above |
| `poddisruptionbudgets` | Same as above |
| `listeners.stackable.tech/listeners` | Same as above — `watch` was added when the listener operator was integrated but no `.owns(Listener)` or `.watches(Listener)` call exists |

### `secrets` reduced to `get, create`

The operator only calls `client.get_opt::<Secret>()` (to check existence) and `client.create()` (to generate the sensitive-property key and OIDC admin password). Secrets are never tracked by `cluster_resources`, so `list`, `delete`, `patch`, `update`, and `watch` are all unnecessary.

### `patch` removed from `nificlusters`

The operator only calls `apply_patch_status()` on NifiCluster objects, which targets the `/status` subresource (covered by the separate `nificlusters/status: patch` rule). The main resource is never patched directly.

### `get` removed from `customresourcedefinitions`

Not needed for crd maintenance, nor startup condition.

---

## Product ClusterRole (`{name}-clusterrole`)

Remove the configmaps/secrets/serviceaccounts get rule for the product clusterrole. Anything needed is mounted. Anything needed by a NiFi processor should have an explicit role and binding made by the admin of the cluster.
