### PR TITLE
docs(crd): fix NiFi authorization usage guide link (usage-guide -> usage_guide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix broken link to the NiFi authorization usage guide in the `spec.clusterConfig.authorization` CRD doc (`usage-guide` -> `usage_guide`) ([#841]).
+- Fix broken link to the NiFi authorization usage guide in the `spec.clusterConfig.authorization` CRD doc (`usage-guide` -> `usage_guide`) ([#924]).
 
-[#841]: https://github.com/stackabletech/nifi-operator/issues/841
 [#903]: https://github.com/stackabletech/nifi-operator/pull/903
 [#916]: https://github.com/stackabletech/nifi-operator/pull/916
 [#921]: https://github.com/stackabletech/nifi-operator/pull/921
 [#922]: https://github.com/stackabletech/nifi-operator/pull/922
+[#924]: https://github.com/stackabletech/nifi-operator/pull/924
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
   Previously, arbitrary keys were silently accepted but ignored ([#921]).
 - Bump `stackable-operator` to 0.110.1 and `kube` to 3.1.0 ([#921]).
 
+### Fixed
+
+- Fix broken link to the NiFi authorization usage guide in the `spec.clusterConfig.authorization` CRD doc (`usage-guide` -> `usage_guide`) ([#841]).
+
+[#841]: https://github.com/stackabletech/nifi-operator/issues/841
 [#903]: https://github.com/stackabletech/nifi-operator/pull/903
 [#916]: https://github.com/stackabletech/nifi-operator/pull/916
 [#921]: https://github.com/stackabletech/nifi-operator/pull/921

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -71,7 +71,7 @@ spec:
                       singleUser: {}
                     description: |-
                       Authorization options.
-                      Learn more in the [NiFi authorization usage guide](https://docs.stackable.tech/home/nightly/nifi/usage-guide/security#authorization).
+                      Learn more in the [NiFi authorization usage guide](https://docs.stackable.tech/home/nightly/nifi/usage_guide/security#authorization).
                     oneOf:
                     - required:
                       - opa

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -129,7 +129,7 @@ pub mod versioned {
         pub authentication: Vec<auth_core::v1alpha1::ClientAuthenticationDetails>,
 
         /// Authorization options.
-        /// Learn more in the [NiFi authorization usage guide](DOCS_BASE_URL_PLACEHOLDER/nifi/usage-guide/security#authorization).
+        /// Learn more in the [NiFi authorization usage guide](DOCS_BASE_URL_PLACEHOLDER/nifi/usage_guide/security#authorization).
         #[serde(default)]
         pub authorization: NifiAuthorization,
 


### PR DESCRIPTION
## Summary

The \`spec.clusterConfig.authorization\` CRD description links to the NiFi authorization usage guide using a hyphenated path:

\`\`\`
https://docs.stackable.tech/home/stable/nifi/usage-guide/security#authorization
\`\`\`

That URL 404s. Every other usage-guide link in this repo (\`authentication\`, \`custom-components\`, \`extra-volumes\`, \`security\`) uses \`usage_guide\` with an underscore, matching the actual docs path (\`docs/modules/nifi/pages/usage_guide/security.adoc\`).

Changes:

- \`rust/operator-binary/src/crd/mod.rs\`: fixed the rustdoc link used to generate the CRD description.
- \`extra/crds.yaml\`: applied the same fix to the checked-in generated CRD so it stays in sync.
- \`CHANGELOG.md\`: added an \"Unreleased / Fixed\" entry referencing this issue.

Closes #841

## Testing

Documentation-only change. Verified:

- new path \`https://docs.stackable.tech/home/stable/nifi/usage_guide/security#authorization\` resolves to the NiFi authorization section;
- all other \`usage_guide\` links in the repo already use the underscore form.