### PR TITLE
docs: link LDAP auth to TLS server verification

### DIFF
--- a/docs/modules/nifi/pages/usage_guide/security.adoc
+++ b/docs/modules/nifi/pages/usage_guide/security.adoc
@@ -110,6 +110,9 @@ spec:
 
 You can follow the xref:tutorials:authentication_with_openldap.adoc[] tutorial to learn how to set up an AuthenticationClass for an LDAP server, as well as consulting the {crd-docs}/authentication.stackable.tech/authenticationclass/v1alpha1/[AuthenticationClass reference {external-link-icon}^].
 
+If your LDAP server uses TLS, the AuthenticationClass also needs to know how to verify the server's certificate.
+See xref:concepts:tls-server-verification.adoc[] for how to provide the LDAP server's CA certificate via a SecretClass.
+
 [#authentication-oidc]
 === OIDC
 


### PR DESCRIPTION
## Description

Sibling to
* https://github.com/stackabletech/documentation/pull/860
* https://github.com/stackabletech/secret-operator/pull/711

Resulting from the same thread.

Describes how to set everything up for verification of CA.