### PR TITLE
feat: Improve startup times by setting `flow.election.max.candidates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#940]).
 - BREAKING: Removed product-config machinery. This is a breaking change in terms of configuration.
   Users relying on the product-config `properties.yaml` file have to set these properties via the CRD ([#945]).
+- In case the user specifies a fixed number of NiFi nodes (i.e. no auto-scaling), set `nifi.cluster.flow.election.max.candidates` to that number.
+  This results in much faster NiFi startups, as it doesn't need to wait for the 5 minutes of `nifi.cluster.flow.election.max.wait.time` ([#953]).
 
 ### Fixed
 
@@ -38,6 +40,7 @@ All notable changes to this project will be documented in this file.
 [#936]: https://github.com/stackabletech/nifi-operator/pull/936
 [#940]: https://github.com/stackabletech/nifi-operator/pull/940
 [#945]: https://github.com/stackabletech/nifi-operator/pull/945
+[#953]: https://github.com/stackabletech/nifi-operator/pull/953
 [#959]: https://github.com/stackabletech/nifi-operator/pull/959
 
 ## [26.3.0] - 2026-03-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1537,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142247df1a93c2b3587402a19710be3e6e942f1581a1702e76408f2c21d6590"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "darling",
  "regex",
@@ -3069,7 +3069,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -3119,8 +3119,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.113.3"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+version = "0.113.4"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "base64",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.5"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "axum",
  "clap",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "kube",
  "schemars",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.2"
-source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#300422ce451e01865debe0cc9da2d75feca14070"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4203,18 +4203,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "k8s-version"
 version = "0.1.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "darling",
  "regex",
@@ -3069,7 +3069,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stackable-certs"
 version = "0.4.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "const-oid",
  "ecdsa",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.113.3"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "base64",
  "clap",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.1.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "jiff",
  "k8s-openapi",
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "stackable-telemetry"
 version = "0.6.5"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "axum",
  "clap",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "kube",
  "schemars",
@@ -3231,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "stackable-versioned-macros"
 version = "0.11.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "convert_case",
  "convert_case_extras",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "stackable-webhook"
 version = "0.9.2"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#013bbf43f7006a4ddfc08a147f68441ed88b462b"
+source = "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#9c9c51a72938a0fd391e92738e3f0ae11ed1efdb"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1003,9 +1003,9 @@ rec {
       };
       "bytes" = rec {
         crateName = "bytes";
-        version = "1.12.0";
+        version = "1.12.1";
         edition = "2021";
-        sha256 = "14xmxm8imyvw675bsgyadmzm9k63js1sdqh7099p0hlj2p9zbqwa";
+        sha256 = "017z19dpg4f942h051m7bpnzcgng042hhcpd7bmg7bjjqd42lrgw";
         authors = [
           "Carl Lerche <me@carllerche.com>"
           "Sean McArthur <sean@seanmonstar.com>"
@@ -5193,8 +5193,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "k8s_version";
@@ -10051,8 +10051,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_certs";
@@ -10267,8 +10267,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_operator";
@@ -10466,8 +10466,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         procMacro = true;
@@ -10501,8 +10501,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_shared";
@@ -10582,8 +10582,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_telemetry";
@@ -10692,8 +10692,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_versioned";
@@ -10742,8 +10742,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         procMacro = true;
@@ -10810,8 +10810,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "013bbf43f7006a4ddfc08a147f68441ed88b462b";
+          url = "https://github.com/stackabletech//operator-rs.git";
+          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_webhook";

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -4817,9 +4817,9 @@ rec {
       };
       "jiff" = rec {
         crateName = "jiff";
-        version = "0.2.31";
+        version = "0.2.32";
         edition = "2021";
-        sha256 = "0d6nvffabb1v34x2s2a3xjca4zny1dfdhqm3xy0wyl77rchn3znc";
+        sha256 = "03lhbin1rcqx84ag8wn6fpaf14wcdar27ck8dy6dvgsj4qw1c7cn";
         authors = [
           "Andrew Gallant <jamslam@gmail.com>"
         ];
@@ -4903,9 +4903,9 @@ rec {
       };
       "jiff-static" = rec {
         crateName = "jiff-static";
-        version = "0.2.31";
+        version = "0.2.32";
         edition = "2021";
-        sha256 = "1lpdrmzd5yafwzniw0xi5gac4rz0vccsja1qrprjim32ysbyhrg1";
+        sha256 = "1k02m2afp1k07rbjqlqhvqyl46ir4v0cq5b65ig4r77rkp9rp1yh";
         procMacro = true;
         libName = "jiff_static";
         authors = [
@@ -4932,9 +4932,9 @@ rec {
       };
       "jiff-tzdb" = rec {
         crateName = "jiff-tzdb";
-        version = "0.1.7";
+        version = "0.1.8";
         edition = "2021";
-        sha256 = "14353p1g4234ww11f6jqy51fkrp31dqijaj0hwsjng59y5yj8hk1";
+        sha256 = "07hl9sgzfb9as1x0n5bjk1qxishzcriapy9xa481y8xd6acx6aql";
         libName = "jiff_tzdb";
         libPath = "lib.rs";
         authors = [
@@ -5193,8 +5193,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "k8s_version";
@@ -10051,8 +10051,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_certs";
@@ -10263,12 +10263,12 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.113.3";
+        version = "0.113.4";
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_operator";
@@ -10466,8 +10466,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         procMacro = true;
@@ -10501,8 +10501,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_shared";
@@ -10582,8 +10582,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_telemetry";
@@ -10692,8 +10692,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_versioned";
@@ -10742,8 +10742,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         procMacro = true;
@@ -10810,8 +10810,8 @@ rec {
         edition = "2024";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/stackabletech//operator-rs.git";
-          rev = "9c9c51a72938a0fd391e92738e3f0ae11ed1efdb";
+          url = "https://github.com/stackabletech/operator-rs.git";
+          rev = "300422ce451e01865debe0cc9da2d75feca14070";
           sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
         };
         libName = "stackable_webhook";
@@ -14779,9 +14779,9 @@ rec {
       };
       "zerocopy" = rec {
         crateName = "zerocopy";
-        version = "0.8.53";
+        version = "0.8.54";
         edition = "2021";
-        sha256 = "1qcdv45iz4499bafwcnflvzf7adfvbnvgfc5w8cx8mk12d9n0wkm";
+        sha256 = "06cxymy8i9q9a93xdins9ayakx9b1nc2arb7qdfd03ssf05brjxp";
         authors = [
           "Joshua Liebow-Feeser <joshlf@google.com>"
           "Jack Wrenn <jswrenn@amazon.com>"
@@ -14815,9 +14815,9 @@ rec {
       };
       "zerocopy-derive" = rec {
         crateName = "zerocopy-derive";
-        version = "0.8.53";
+        version = "0.8.54";
         edition = "2021";
-        sha256 = "0wgxvsnv44x5xdli270xh085458m76dkl0iqjpa3624hry9gs527";
+        sha256 = "1xb292dhgb0d4fs05cdj2s0v3srmk7bajv94sdc7631dnnvigs72";
         procMacro = true;
         libName = "zerocopy_derive";
         authors = [

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -5195,7 +5195,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "k8s_version";
         authors = [
@@ -10053,7 +10053,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_certs";
         authors = [
@@ -10269,7 +10269,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_operator";
         authors = [
@@ -10468,7 +10468,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -10503,7 +10503,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_shared";
         authors = [
@@ -10584,7 +10584,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -10694,7 +10694,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_versioned";
         authors = [
@@ -10744,7 +10744,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";
@@ -10812,7 +10812,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "300422ce451e01865debe0cc9da2d75feca14070";
-          sha256 = "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps";
+          sha256 = "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh";
         };
         libName = "stackable_webhook";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 repository = "https://github.com/stackabletech/nifi-operator"
 
 [workspace.dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.113.3", features = ["webhook"] }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.113.4", features = ["webhook"] }
 
 anyhow = "1.0"
 built = { version = "0.8", features = ["chrono", "git2"] }
@@ -34,5 +34,5 @@ tracing = "0.1"
 url = { version = "2.5.7" }
 
 [patch."https://github.com/stackabletech/operator-rs.git"]
-stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "refactor/replica-counting" }
+# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ tokio = { version = "1.52", features = ["full"] }
 tracing = "0.1"
 url = { version = "2.5.7" }
 
-# [patch."https://github.com/stackabletech/operator-rs.git"]
-# stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "main" }
+[patch."https://github.com/stackabletech/operator-rs.git"]
+stackable-operator = { git = "https://github.com/stackabletech//operator-rs.git", branch = "refactor/replica-counting" }
 # stackable-operator = { path = "../operator-rs/crates/stackable-operator" }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator@0.113.4": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#k8s-version@0.1.3": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-certs@0.4.1": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator-derive@0.3.1": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator@0.113.4": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-shared@0.1.2": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-telemetry@0.6.5": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned-macros@0.11.1": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned@0.11.1": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-webhook@0.9.2": "1la11wxj8cz2n0557i46qaihr88hl3jgk9352h9ws3q2f2wi7qsh",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-operator@0.113.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-operator@0.113.4": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.4#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,12 +1,12 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-operator@0.113.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.113.3#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#k8s-version@0.1.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-certs@0.4.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-operator-derive@0.3.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-operator@0.113.3": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-shared@0.1.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-telemetry@0.6.5": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-versioned-macros@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-versioned@0.11.1": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
+  "git+https://github.com/stackabletech//operator-rs.git?branch=refactor%2Freplica-counting#stackable-webhook@0.9.2": "054p2mcinq3x4iykmc72nhga7kapc8ihkx9mnzqq3qdm2bk2qcps",
   "git+https://github.com/stackabletech/product-config.git?tag=0.8.0#product-config@0.8.0": "1dz70kapm2wdqcr7ndyjji0lhsl98bsq95gnb2lw487wf6yr7987"
 }

--- a/docs/modules/nifi/assets/attachments/entraid-nifi.yaml
+++ b/docs/modules/nifi/assets/attachments/entraid-nifi.yaml
@@ -204,7 +204,6 @@ spec:
         nifi.security.user.oidc.additional.scopes: "profile"
         nifi.security.user.oidc.claim.identifying.user: "upn"
         nifi.process.group.root.placeholder: "root"
-        nifi.cluster.flow.election.max.wait.time: "10 secs"
     podOverrides:
       spec:
         initContainers:

--- a/docs/modules/nifi/pages/usage_guide/overrides.adoc
+++ b/docs/modules/nifi/pages/usage_guide/overrides.adoc
@@ -71,7 +71,6 @@ For example per role group:
 nodes:
   roleGroups:
     default:
-      config: {}
       replicas: 1
       envOverrides:
         MY_ENV_VAR: "MY_VALUE"
@@ -86,7 +85,6 @@ nodes:
     MY_ENV_VAR: "MY_VALUE"
   roleGroups:
     default:
-      config: {}
       replicas: 1
 ----
 

--- a/rust/operator-binary/src/controller/build/properties/nifi_properties.rs
+++ b/rust/operator-binary/src/controller/build/properties/nifi_properties.rs
@@ -3,7 +3,10 @@
 use std::collections::BTreeMap;
 
 use snafu::{ResultExt, Snafu, ensure};
-use stackable_operator::memory::MemoryQuantity;
+use stackable_operator::{
+    memory::MemoryQuantity,
+    role_utils::{ZeroReplicasCounting, fixed_replica_count},
+};
 
 use super::{
     ConfigFileName, env_reference, file_reference, format_properties,
@@ -21,7 +24,7 @@ use crate::{
             },
         },
     },
-    crd::{storage::NifiRepository, v1alpha1},
+    crd::{NifiRole, storage::NifiRepository, v1alpha1},
     security::{
         authentication::{
             NifiAuthenticationConfig, STACKABLE_SERVER_TLS_DIR, STACKABLE_TLS_STORE_PASSWORD,
@@ -526,9 +529,26 @@ pub fn build(
         "nifi.cluster.node.protocol.port".to_string(),
         PROTOCOL_PORT.to_string(),
     );
+
+    // In case the number of NiFi nodes is hard-coded to a fixed number (no auto-scaling), we can
+    // tell this NiFi, so that startup is much quicker.
+    let fixed_replica_count = fixed_replica_count(
+        cluster
+            .role_group_configs
+            .get(&NifiRole::Node)
+            .iter()
+            .flat_map(|nodes| nodes.values())
+            .map(|rg| rg.replicas),
+        // We rather treat explicit 0 values as [`None`], so that we don't end up with too few nodes
+        ZeroReplicasCounting::TreatAsZero,
+    );
+    let max_election_candidates = fixed_replica_count
+        .map(|count| count.to_string())
+        // In case we don't know the replica count, we set it to "" as that's what we always did
+        .unwrap_or_default();
     properties.insert(
         "nifi.cluster.flow.election.max.candidates".to_string(),
-        "".to_string(),
+        max_election_candidates,
     );
 
     match cluster.cluster_config.clustering_backend {

--- a/tests/templates/kuttl/cluster-sync-cs-bug/20-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster-sync-cs-bug/20-install-nifi.yaml.j2
@@ -186,8 +186,6 @@ spec:
       nifi.properties:
         nifi.web.https.sni.required: "false"
         nifi.web.https.sni.host.check: "false"
-        # Quicker startup, and we only have a single node
-        nifi.cluster.flow.election.max.wait.time: "10 secs"
     podOverrides:
       spec:
         initContainers:

--- a/tests/templates/kuttl/cluster_operation/20-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/20-install-nifi.yaml.j2
@@ -50,10 +50,6 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleGroups:
       default:
         replicas: 2

--- a/tests/templates/kuttl/custom-components-git-sync/30_install-nifi.yaml.j2
+++ b/tests/templates/kuttl/custom-components-git-sync/30_install-nifi.yaml.j2
@@ -67,10 +67,6 @@ spec:
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleConfig:
       listenerClass: external-unstable
     podOverrides:

--- a/tests/templates/kuttl/external-access/30_nifi.yaml.j2
+++ b/tests/templates/kuttl/external-access/30_nifi.yaml.j2
@@ -53,10 +53,6 @@ spec:
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleConfig:
       listenerClass: test-external-unstable-$NAMESPACE
     roleGroups:

--- a/tests/templates/kuttl/iceberg-hive/34_trino.yaml.j2
+++ b/tests/templates/kuttl/iceberg-hive/34_trino.yaml.j2
@@ -104,4 +104,3 @@ spec:
     roleGroups:
       default:
         replicas: 1
-        config: {}

--- a/tests/templates/kuttl/iceberg-hive/50_nifi.yaml.j2
+++ b/tests/templates/kuttl/iceberg-hive/50_nifi.yaml.j2
@@ -56,9 +56,6 @@ spec:
 {% if test_scenario['values']['iceberg-use-kerberos'] == 'true' %}
         nifi.kerberos.krb5.file: /stackable/userdata/kerberos/krb5.conf
 {% endif %}
-
-        # Quicker startup, and we only have a single node
-        nifi.cluster.flow.election.max.wait.time: 5 secs
     jvmArgumentOverrides:
       add:
         # Needed for NiFi to trust the minio cert

--- a/tests/templates/kuttl/iceberg-rest/50_nifi.yaml.j2
+++ b/tests/templates/kuttl/iceberg-rest/50_nifi.yaml.j2
@@ -26,10 +26,6 @@ spec:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleConfig:
       listenerClass: external-unstable
-    configOverrides:
-      nifi.properties:
-        # Quicker startup, and we only have a single node
-        nifi.cluster.flow.election.max.wait.time: 5 secs
     jvmArgumentOverrides:
       add:
         # Needed for NiFi to trust the minio cert

--- a/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/ldap/12-install-nifi.yaml.j2
@@ -54,13 +54,8 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleConfig:
       listenerClass: external-unstable
     roleGroups:
       default:
-        config: {}
         replicas: 2

--- a/tests/templates/kuttl/logging/04-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/logging/04-install-nifi.yaml.j2
@@ -105,10 +105,6 @@ spec:
   nodes:
     config:
       gracefulShutdownTimeout: 1m
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleGroups:
       automatic-log-config:
         replicas: 1

--- a/tests/templates/kuttl/oidc-opa/19-assert.yaml
+++ b/tests/templates/kuttl/oidc-opa/19-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 600
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/templates/kuttl/oidc-opa/30_nifi.yaml.j2
+++ b/tests/templates/kuttl/oidc-opa/30_nifi.yaml.j2
@@ -44,10 +44,6 @@ spec:
       gracefulShutdownTimeout: 1s # let the tests run faster
     roleConfig:
       listenerClass: external-unstable
-    configOverrides:
-      nifi.properties:
-        # speed up tests
-        nifi.cluster.flow.election.max.wait.time: 10 secs
     podOverrides:
       spec:
         initContainers:
@@ -71,5 +67,4 @@ spec:
           name: nifi-flow-json
     roleGroups:
       default:
-        config: {}
         replicas: 1

--- a/tests/templates/kuttl/orphaned_resources/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/02-install-nifi.yaml.j2
@@ -51,14 +51,8 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleGroups:
       default:
-        config: {}
         replicas: 2
       throwaway:
-        config: {}
         replicas: 1

--- a/tests/templates/kuttl/resources/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/resources/02-install-nifi.yaml.j2
@@ -68,10 +68,6 @@ spec:
             capacity: 2Gi
           stateRepo:
             capacity: 2Gi
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleGroups:
       resources-from-role:
         replicas: 1

--- a/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-nifi.yaml.j2
@@ -70,11 +70,9 @@ spec:
       COMMON_VAR: role-value # overridden by role group below
       ROLE_VAR: role-value   # only defined here at role level
     configOverrides:
-      "nifi.properties":
-        "nifi.diagnostics.on.shutdown.enabled": "true"
-        "nifi.diagnostics.on.shutdown.verbose": "false"
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
+      nifi.properties:
+        nifi.diagnostics.on.shutdown.enabled: "true"
+        nifi.diagnostics.on.shutdown.verbose: "false"
     config:
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}

--- a/tests/templates/kuttl/smoke/35-assert.yaml.j2
+++ b/tests/templates/kuttl/smoke/35-assert.yaml.j2
@@ -122,8 +122,7 @@ commands:
       nifi.properties: |
         nifi.administrative.yield.duration=30 sec
         nifi.authorizer.configuration.file=/stackable/nifi/conf/authorizers.xml
-        nifi.cluster.flow.election.max.candidates=
-        nifi.cluster.flow.election.max.wait.time=10 secs
+        nifi.cluster.flow.election.max.candidates=2
         nifi.cluster.is.node=true
 {% if test_scenario['values']['use-zookeeper-manager'] == 'true' %}
         nifi.cluster.leader.election.implementation=CuratorLeaderElectionManager

--- a/tests/templates/kuttl/smoke/test_nifi.py
+++ b/tests/templates/kuttl/smoke/test_nifi.py
@@ -52,13 +52,15 @@ if __name__ == "__main__":
     node_count = int(args["count"])
 
     x = 0
-    while x < 15:
+    while x < 30:
         url = host + "/nifi-api/controller/cluster"
         cluster = requests.get(
             url, headers=headers, verify=False
         )  # , cert='/tmp/cacert.pem')
         if cluster.status_code != 200:
-            print("Waiting for cluster...")
+            print(
+                f"Waiting for cluster (HTTP status code was {cluster.status_code})..."
+            )
         else:
             cluster_data = json.loads(cluster.content.decode("utf-8"))
             nodes = cluster_data["cluster"]["nodes"]

--- a/tests/templates/kuttl/upgrade/02-install-nifi.yaml.j2
+++ b/tests/templates/kuttl/upgrade/02-install-nifi.yaml.j2
@@ -51,11 +51,6 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-    configOverrides:
-      "nifi.properties":
-        # Quicker startup, and we only have a single node
-        "nifi.cluster.flow.election.max.wait.time": "10 secs"
     roleGroups:
       default:
-        config: {}
         replicas: 3


### PR DESCRIPTION
## Description

TLDR: In case the user specifies a fixed number of NiFi nodes (i.e. no auto-scaling), set  `nifi.cluster.flow.election.max.candidates` to that number. This results in much faster NiFi startups, as it doesn't need to wait for the 5 minutes of `nifi.cluster.flow.election.max.wait.time` 

(disclaimer: AI helped my on the description, code is mine)

NiFi uses flow election on cold start: nodes vote on which flow definition wins, and the cluster won't finish coming up until election settles. Two things gate that:

- nifi.cluster.flow.election.max.wait.time — the timeout the cluster waits before electing among whoever has shown up.
- nifi.cluster.flow.election.max.candidates — a shortcut: elect immediately once this many nodes have connected and voted, without waiting out the timeout.

In #936 we correctly raised max.wait.time back to NiFi's upstream default of 5 minutes (the previous 1 min was a leftover "for testing" value that risked electing on incomplete vote sets). That fixed the correctness problem, but it left every cold start paying up to 5 minutes before the cluster is usable — because we were leaving max.candidates empty, so the timeout was the only thing that ended election.

The pain is real and already visible: many of our own kuttl tests, as well as customers, have been reaching for configOverrides to lower max.wait.time again simply because a 5-minute startup is too slow to live with.

This PR resolves the tension instead of trading one problem for the other. When the number of NiFi nodes is fixed (all role-group replicas are set, i.e. no autoscaling), the operator knows the exact node count and sets max.candidates to it. On cold start the cluster now elects the moment all expected nodes have reported in — typically seconds — while max.wait.time stays at the safe 5-minute upstream default as a fallback for the degraded case (a node that never joins).

The result:
- Fast startups without lowering the safety timeout.
- No correctness regression — if fewer nodes than expected show up, behavior is identical to before (wait out the timeout, then elect).
- No more manual max.wait.time overrides in tests and customer clusters.

This is safe on our StatefulSet setup specifically because pods use podManagementPolicy: Parallel, so all expected nodes start concurrently and the "elect once all candidates are present" fast path can actually trigger. When replicas is left unset anywhere (autoscaling), we fall back to the previous empty value.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)

### Release notes

For clusters with a fixed number of nodes, the operator now sets `nifi.cluster.flow.election.max.candidates` to the total node count, so cold-start flow election completes as soon as all expected nodes report in — typically seconds instead of the up-to-5-minute `max.wait.time timeout`. The timeout stays at NiFi's upstream default of 5 minutes as a fallback, so there's no correctness change if fewer nodes than expected show up.