### PR TITLE
refactor: Use stackable-operators ProbeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
   `secrets` ([#974]).
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#975]).
 - NiFi startup and readiness probes now use the local management server's `/health` and
-  `/health/cluster` endpoints instead of a bare TCP check ([#976]).
+  `/health/cluster` endpoints instead of a bare TCP check ([#976], [#981]).
 
 ### Fixed
 
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#974]: https://github.com/stackabletech/nifi-operator/pull/974
 [#975]: https://github.com/stackabletech/nifi-operator/pull/975
 [#976]: https://github.com/stackabletech/nifi-operator/pull/976
+[#981]: https://github.com/stackabletech/nifi-operator/pull/981
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -6,46 +6,46 @@
 //! probes using `curl` from inside the container - a `httpGet` probe cannot
 //! reach a loopback-only address.
 
-use stackable_operator::k8s_openapi::{
-    api::core::v1::{ExecAction, Probe, TCPSocketAction},
-    apimachinery::pkg::util::intstr::IntOrString,
+use stackable_operator::{
+    builder::pod::probe::{ProbeAction, ProbeBuilder},
+    k8s_openapi::{
+        api::core::v1::{Probe, TCPSocketAction},
+        apimachinery::pkg::util::intstr::IntOrString,
+    },
+    shared::time::Duration,
 };
 
 use crate::controller::build::{
     HTTPS_PORT_NAME, MANAGEMENT_SERVER_ADDRESS, MANAGEMENT_SERVER_PORT,
 };
 
-fn management_health_exec(path: &str) -> ExecAction {
-    ExecAction {
-        command: Some(vec![
-            "/bin/bash".to_string(),
-            "-euo".to_string(),
-            "pipefail".to_string(),
-            "-c".to_string(),
-            format!(
-                "curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}{path}"
-            ),
-        ]),
-    }
+fn common_probe_baseline(path: &str) -> ProbeBuilder<ProbeAction, Duration> {
+    ProbeBuilder::exec_command([
+        "/bin/bash".to_string(),
+        "-euo".to_string(),
+        "pipefail".to_string(),
+        "-c".to_string(),
+        format!("curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}{path}"),
+    ])
+    .with_period(Duration::from_secs(10))
+    .with_timeout(Duration::from_secs(5))
 }
+
 pub fn management_startup_probe() -> Probe {
-    Probe {
-        initial_delay_seconds: Some(10),
-        period_seconds: Some(10),
-        timeout_seconds: Some(5),
-        failure_threshold: Some(20 * 6),
-        exec: Some(management_health_exec("/health")),
-        ..Probe::default()
-    }
+    common_probe_baseline("/health")
+        .with_initial_delay(Duration::from_secs(10))
+        .with_failure_threshold_duration(Duration::from_minutes_unchecked(20))
+        .expect("static period is non-zero")
+        .build()
+        .expect("static duration is not too long")
 }
+
 pub fn management_readiness_probe() -> Probe {
-    Probe {
-        period_seconds: Some(10),
-        timeout_seconds: Some(5),
-        failure_threshold: Some(3),
-        exec: Some(management_health_exec("/health/cluster")),
-        ..Probe::default()
-    }
+    common_probe_baseline("/health/cluster")
+        .with_failure_threshold_duration(Duration::from_secs(30))
+        .expect("static period is non-zero")
+        .build()
+        .expect("static duration is not too long")
 }
 
 pub fn tcp_liveliness_probe() -> Probe {
@@ -107,7 +107,8 @@ mod tests {
         assert_eq!(probe.failure_threshold, Some(3));
         assert_eq!(probe.timeout_seconds, Some(5));
         assert_eq!(
-            probe.initial_delay_seconds, None,
+            probe.initial_delay_seconds,
+            Some(0),
             "readiness probe delay is redundant: k8s already suppresses readiness checks \
              until the startup probe succeeds"
         );


### PR DESCRIPTION
## Description

Follow-up of https://github.com/stackabletech/nifi-operator/pull/976.
We don't change any values (ok, technically initialDelaySeconds is not set to 0 instead of `null`), only the builder is used.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
