### PR TITLE
refactor: check /health/cluster response body and use ProbeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
   `secrets` ([#974]).
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#975]).
 - NiFi startup and readiness probes now use the local management server's `/health` and
-  `/health/cluster` endpoints instead of a bare TCP check ([#976]).
+  `/health/cluster` endpoints instead of a bare TCP check ([#976], [#981]).
 
 ### Fixed
 
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 [#974]: https://github.com/stackabletech/nifi-operator/pull/974
 [#975]: https://github.com/stackabletech/nifi-operator/pull/975
 [#976]: https://github.com/stackabletech/nifi-operator/pull/976
+[#981]: https://github.com/stackabletech/nifi-operator/pull/981
 
 ## [26.7.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
   `secrets` ([#974]).
 - All product containers now run with `securityContext.runAsNonRoot` set to `true` to improve security ([#975]).
 - NiFi startup and readiness probes now use the local management server's `/health` and
-  `/health/cluster` endpoints instead of a bare TCP check ([#976], [#981]).
+  `/health/cluster` endpoints instead of a bare TCP check ([#976], [#982]).
 
 ### Fixed
 
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.
 [#974]: https://github.com/stackabletech/nifi-operator/pull/974
 [#975]: https://github.com/stackabletech/nifi-operator/pull/975
 [#976]: https://github.com/stackabletech/nifi-operator/pull/976
-[#981]: https://github.com/stackabletech/nifi-operator/pull/981
+[#982]: https://github.com/stackabletech/nifi-operator/pull/982
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -6,76 +6,74 @@
 //! probes using `curl` from inside the container - a `httpGet` probe cannot
 //! reach a loopback-only address.
 
-use stackable_operator::k8s_openapi::{
-    api::core::v1::{ExecAction, Probe, TCPSocketAction},
-    apimachinery::pkg::util::intstr::IntOrString,
+use stackable_operator::{
+    builder::pod::probe::ProbeBuilder,
+    k8s_openapi::{
+        api::core::v1::{Probe, TCPSocketAction},
+        apimachinery::pkg::util::intstr::IntOrString,
+    },
+    shared::time::Duration,
 };
 
 use crate::controller::build::{
     HTTPS_PORT_NAME, MANAGEMENT_SERVER_ADDRESS, MANAGEMENT_SERVER_PORT,
 };
 
-fn management_health_exec(path: &str) -> ExecAction {
-    ExecAction {
-        command: Some(vec![
-            "/bin/bash".to_string(),
-            "-euo".to_string(),
-            "pipefail".to_string(),
-            "-c".to_string(),
-            format!(
-                "curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}{path}"
-            ),
-        ]),
-    }
+fn management_health_exec_command(path: &str) -> Vec<String> {
+    vec![
+        "/bin/bash".to_string(),
+        "-euo".to_string(),
+        "pipefail".to_string(),
+        "-c".to_string(),
+        format!(
+            "curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}{path}"
+        ),
+    ]
 }
 
 /// NiFi's `/health/cluster` endpoint returns HTTP 200 for both `CONNECTING`
 /// and `CONNECTED`, so the readiness probe greps for that instead of only
 /// checking the return code.
-fn management_cluster_connected_exec() -> ExecAction {
-    ExecAction {
-        command: Some(vec![
-            "/bin/bash".to_string(),
-            "-euo".to_string(),
-            "pipefail".to_string(),
-            "-c".to_string(),
-            format!(
-                "curl --fail --silent --show-error http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}/health/cluster | grep -q 'Cluster Status: CONNECTED'"
-            ),
-        ]),
-    }
+fn management_cluster_connected_exec_command() -> Vec<String> {
+    vec![
+        "/bin/bash".to_string(),
+        "-euo".to_string(),
+        "pipefail".to_string(),
+        "-c".to_string(),
+        format!(
+            "curl --fail --silent --show-error http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}/health/cluster | grep -q 'Cluster Status: CONNECTED'"
+        ),
+    ]
 }
 
 pub fn management_startup_probe() -> Probe {
-    Probe {
-        initial_delay_seconds: Some(10),
-        period_seconds: Some(10),
-        timeout_seconds: Some(5),
-        failure_threshold: Some(20 * 6),
-        exec: Some(management_health_exec("/health")),
-        ..Probe::default()
-    }
+    ProbeBuilder::exec_command(management_health_exec_command("/health"))
+        .with_period(Duration::from_secs(10))
+        .with_initial_delay(Duration::from_secs(10))
+        .with_timeout(Duration::from_secs(5))
+        .with_failure_threshold(20 * 6)
+        .build()
+        .expect("the startup probe's durations must fit into an i32")
 }
+
 pub fn management_readiness_probe() -> Probe {
-    Probe {
-        period_seconds: Some(10),
-        timeout_seconds: Some(5),
-        failure_threshold: Some(3),
-        exec: Some(management_cluster_connected_exec()),
-        ..Probe::default()
-    }
+    ProbeBuilder::exec_command(management_cluster_connected_exec_command())
+        .with_period(Duration::from_secs(10))
+        .with_timeout(Duration::from_secs(5))
+        .with_failure_threshold(3)
+        .build()
+        .expect("the readiness probe's durations must fit into an i32")
 }
 
 pub fn tcp_liveliness_probe() -> Probe {
-    Probe {
-        initial_delay_seconds: Some(10),
-        period_seconds: Some(10),
-        tcp_socket: Some(TCPSocketAction {
-            port: IntOrString::String(HTTPS_PORT_NAME.to_string()),
-            ..TCPSocketAction::default()
-        }),
-        ..Probe::default()
-    }
+    ProbeBuilder::tcp_socket(TCPSocketAction {
+        port: IntOrString::String(HTTPS_PORT_NAME.to_string()),
+        ..Default::default()
+    })
+    .with_period(Duration::from_secs(10))
+    .with_initial_delay(Duration::from_secs(10))
+    .build()
+    .expect("the liveliness probe's durations must fit into an i32")
 }
 
 #[cfg(test)]
@@ -125,7 +123,8 @@ mod tests {
         assert_eq!(probe.failure_threshold, Some(3));
         assert_eq!(probe.timeout_seconds, Some(5));
         assert_eq!(
-            probe.initial_delay_seconds, None,
+            probe.initial_delay_seconds,
+            Some(0),
             "readiness probe delay is redundant: k8s already suppresses readiness checks \
              until the startup probe succeeds"
         );

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -19,14 +19,14 @@ use crate::controller::build::{
     HTTPS_PORT_NAME, MANAGEMENT_SERVER_ADDRESS, MANAGEMENT_SERVER_PORT,
 };
 
-fn management_health_exec_command(path: &str) -> [String; 5] {
+fn management_health_exec_command() -> [String; 5] {
     [
         "/bin/bash".to_string(),
         "-euo".to_string(),
         "pipefail".to_string(),
         "-c".to_string(),
         format!(
-            "curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}{path}"
+            "curl --fail --silent --show-error --output /dev/null http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}/health"
         ),
     ]
 }
@@ -47,7 +47,7 @@ fn management_cluster_connected_exec_command() -> [String; 5] {
 }
 
 pub fn management_startup_probe() -> Probe {
-    ProbeBuilder::exec_command(management_health_exec_command("/health"))
+    ProbeBuilder::exec_command(management_health_exec_command())
         .with_period(Duration::from_secs(10))
         .with_initial_delay(Duration::from_secs(10))
         .with_timeout(Duration::from_secs(5))

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -46,6 +46,19 @@ fn management_cluster_connected_exec_command() -> [String; 5] {
     ]
 }
 
+/// The startup probe fails after roughly 20 minutes.
+///
+/// Nifi might take a very long time to start up due to the following factors:
+/// - JVM cold starts are usually slow.
+/// - It expands NAR bundles (each processor/controller-service bundle) into
+///   the working directory and builds a classloader per NAR.
+/// - It replays/rolls back the FlowFile repository  to reconstruct in-flight
+///   FlowFile state.
+///   If the previous shutdown wasn't clean, or there's a large backlog of
+///   in-flight FlowFiles, this replay can take a while.
+///   Content and provenance repositories also do startup housekeeping.
+/// - Large flow definitions take longer to deserialize and instantiate into
+///   the running flow controller graph.
 pub fn management_startup_probe() -> Probe {
     ProbeBuilder::exec_command(management_health_exec_command())
         .with_period(Duration::from_secs(10))
@@ -57,6 +70,11 @@ pub fn management_startup_probe() -> Probe {
         .expect("the startup probe's durations must fit into an i32")
 }
 
+/// The readiness probe fails after roughly 5 minutes.
+///
+/// In clustered mode, a node connecting has to talk to the cluster coordinator,
+/// participate in flow election/inheritance, and reconcile its local flow against
+/// the cluster's.
 pub fn management_readiness_probe() -> Probe {
     ProbeBuilder::exec_command(management_cluster_connected_exec_command())
         .with_period(Duration::from_secs(10))
@@ -73,7 +91,6 @@ pub fn tcp_liveness_probe() -> Probe {
         ..Default::default()
     })
     .with_period(Duration::from_secs(10))
-    .with_initial_delay(Duration::from_secs(10))
     .build()
     .expect("the liveness probe's durations must fit into an i32")
 }

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -28,6 +28,24 @@ fn management_health_exec(path: &str) -> ExecAction {
         ]),
     }
 }
+
+/// NiFi's `/health/cluster` endpoint returns HTTP 200 for both `CONNECTING`
+/// and `CONNECTED`, so the readiness probe greps for that instead of only
+/// checking the return code.
+fn management_cluster_connected_exec() -> ExecAction {
+    ExecAction {
+        command: Some(vec![
+            "/bin/bash".to_string(),
+            "-euo".to_string(),
+            "pipefail".to_string(),
+            "-c".to_string(),
+            format!(
+                "curl --fail --silent --show-error http://{MANAGEMENT_SERVER_ADDRESS}:{MANAGEMENT_SERVER_PORT}/health/cluster | grep -q 'Cluster Status: CONNECTED'"
+            ),
+        ]),
+    }
+}
+
 pub fn management_startup_probe() -> Probe {
     Probe {
         initial_delay_seconds: Some(10),
@@ -43,7 +61,7 @@ pub fn management_readiness_probe() -> Probe {
         period_seconds: Some(10),
         timeout_seconds: Some(5),
         failure_threshold: Some(3),
-        exec: Some(management_health_exec("/health/cluster")),
+        exec: Some(management_cluster_connected_exec()),
         ..Probe::default()
     }
 }
@@ -110,6 +128,32 @@ mod tests {
             probe.initial_delay_seconds, None,
             "readiness probe delay is redundant: k8s already suppresses readiness checks \
              until the startup probe succeeds"
+        );
+    }
+
+    #[test]
+    fn readiness_probe_greps_body_for_connected_status() {
+        // NiFi's /health/cluster endpoint returns HTTP 200 for both
+        // CONNECTING and CONNECTED nodes, so the return code alone can't
+        // distinguish a node that is still joining from one that has
+        // actually joined. The probe must inspect the response body.
+        let probe = management_readiness_probe();
+
+        let command = probe
+            .exec
+            .expect("readiness probe must be an exec probe")
+            .command
+            .expect("exec action must have a command");
+        let script = command.last().expect("bash -c script argument");
+
+        assert!(
+            script.contains("grep") && script.contains("Cluster Status: CONNECTED"),
+            "expected the probe to grep the response body for \"Cluster Status: CONNECTED\", \
+             got: {script}"
+        );
+        assert!(
+            !script.contains("--output /dev/null"),
+            "the response body must not be discarded, the probe needs to inspect it: {script}"
         );
     }
 

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -60,12 +60,12 @@ pub fn management_readiness_probe() -> Probe {
     ProbeBuilder::exec_command(management_cluster_connected_exec_command())
         .with_period(Duration::from_secs(10))
         .with_timeout(Duration::from_secs(5))
-        .with_failure_threshold(3)
+        .with_failure_threshold(30)
         .build()
         .expect("the readiness probe's durations must fit into an i32")
 }
 
-pub fn tcp_liveliness_probe() -> Probe {
+pub fn tcp_liveness_probe() -> Probe {
     ProbeBuilder::tcp_socket(TCPSocketAction {
         port: IntOrString::String(HTTPS_PORT_NAME.to_string()),
         ..Default::default()
@@ -73,7 +73,7 @@ pub fn tcp_liveliness_probe() -> Probe {
     .with_period(Duration::from_secs(10))
     .with_initial_delay(Duration::from_secs(10))
     .build()
-    .expect("the liveliness probe's durations must fit into an i32")
+    .expect("the liveness probe's durations must fit into an i32")
 }
 
 #[cfg(test)]
@@ -120,7 +120,7 @@ mod tests {
             script.contains(&cluster_health_url),
             "expected curl against /health/cluster, got: {script}"
         );
-        assert_eq!(probe.failure_threshold, Some(3));
+        assert_eq!(probe.failure_threshold, Some(30));
         assert_eq!(probe.timeout_seconds, Some(5));
         assert_eq!(
             probe.initial_delay_seconds,

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -46,7 +46,7 @@ fn management_cluster_connected_exec_command() -> [String; 5] {
     ]
 }
 
-/// The startup probe fails after roughly 20 minutes.
+/// We give up on the startup probe after ~20 minutes.
 ///
 /// Nifi might take a very long time to start up due to the following factors:
 /// - JVM cold starts are usually slow.
@@ -70,7 +70,7 @@ pub fn management_startup_probe() -> Probe {
         .expect("the startup probe's durations must fit into an i32")
 }
 
-/// The readiness probe fails after roughly 5 minutes.
+/// We give up on the readiness probe after ~5 minutes.
 ///
 /// In clustered mode, a node connecting has to talk to the cluster coordinator,
 /// participate in flow election/inheritance, and reconcile its local flow against

--- a/rust/operator-binary/src/controller/build/resource/probes.rs
+++ b/rust/operator-binary/src/controller/build/resource/probes.rs
@@ -19,8 +19,8 @@ use crate::controller::build::{
     HTTPS_PORT_NAME, MANAGEMENT_SERVER_ADDRESS, MANAGEMENT_SERVER_PORT,
 };
 
-fn management_health_exec_command(path: &str) -> Vec<String> {
-    vec![
+fn management_health_exec_command(path: &str) -> [String; 5] {
+    [
         "/bin/bash".to_string(),
         "-euo".to_string(),
         "pipefail".to_string(),
@@ -34,8 +34,8 @@ fn management_health_exec_command(path: &str) -> Vec<String> {
 /// NiFi's `/health/cluster` endpoint returns HTTP 200 for both `CONNECTING`
 /// and `CONNECTED`, so the readiness probe greps for that instead of only
 /// checking the return code.
-fn management_cluster_connected_exec_command() -> Vec<String> {
-    vec![
+fn management_cluster_connected_exec_command() -> [String; 5] {
+    [
         "/bin/bash".to_string(),
         "-euo".to_string(),
         "pipefail".to_string(),
@@ -51,7 +51,8 @@ pub fn management_startup_probe() -> Probe {
         .with_period(Duration::from_secs(10))
         .with_initial_delay(Duration::from_secs(10))
         .with_timeout(Duration::from_secs(5))
-        .with_failure_threshold(20 * 6)
+        .with_failure_threshold_duration(Duration::from_minutes_unchecked(20))
+        .expect("static period is non-zero")
         .build()
         .expect("the startup probe's durations must fit into an i32")
 }
@@ -60,7 +61,8 @@ pub fn management_readiness_probe() -> Probe {
     ProbeBuilder::exec_command(management_cluster_connected_exec_command())
         .with_period(Duration::from_secs(10))
         .with_timeout(Duration::from_secs(5))
-        .with_failure_threshold(30)
+        .with_failure_threshold_duration(Duration::from_minutes_unchecked(5))
+        .expect("static period is non-zero")
         .build()
         .expect("the readiness probe's durations must fit into an i32")
 }

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -61,7 +61,7 @@ use crate::{
                     group_listener_name,
                 },
                 probes::{
-                    management_readiness_probe, management_startup_probe, tcp_liveliness_probe,
+                    management_readiness_probe, management_startup_probe, tcp_liveness_probe,
                 },
             },
         },
@@ -442,7 +442,7 @@ pub(crate) fn build_node_rolegroup_statefulset(
         .add_container_port(HTTPS_PORT_NAME, HTTPS_PORT.into())
         .add_container_port(PROTOCOL_PORT_NAME, PROTOCOL_PORT.into())
         .add_container_port(BALANCE_PORT_NAME, BALANCE_PORT.into())
-        .liveness_probe(tcp_liveliness_probe())
+        .liveness_probe(tcp_liveness_probe())
         .startup_probe(management_startup_probe())
         .readiness_probe(management_readiness_probe())
         .resources(merged_config.resources.clone().into());


### PR DESCRIPTION
## Description

```
--- PASS: kuttl (318.65s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_nifi-2.9.0_use-zookeeper-manager-true_zookeeper-3.9.5_openshift-false_listener-class-external-unstable (318.64s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
