### PR TITLE
fix(tests): add vector container to cluster operations check

### DIFF
--- a/tests/templates/kuttl/cluster_operation/20-assert.yaml.j2
+++ b/tests/templates/kuttl/cluster_operation/20-assert.yaml.j2
@@ -40,3 +40,6 @@ spec:
                 - pipefail
                 - -c
                 - "curl --fail --silent --show-error http://127.0.0.1:52020/health/cluster | grep -q 'Cluster Status: CONNECTED'"
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+        - name: vector
+{% endif %}


### PR DESCRIPTION
## Description

failed since the readiness probe rework https://github.com/stackabletech/nifi-operator/pull/976

```
resource StatefulSet:kuttl-test-free-parrot/test-nifi-node-default: .spec.template.spec.containers: slice length mismatch: 1 != 2
```

No adds the vector container.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
